### PR TITLE
fix: Post-trade overlay refresh — TRADE → SUIAMI transition

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -118,7 +118,7 @@
 
   <div id="ski-modal"></div>
 
-  <script type="module" src="./dist/ski.js?v=20260330d"></script>
+  <script type="module" src="./dist/ski.js?v=20260330f"></script>
   <script>
     (function() {
       var addrs = {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8332,6 +8332,8 @@ function renderSkiMenu() {
         walletCoins = []; appBalanceFetched = false;
         renderSkiMenu();
         setTimeout(() => refreshPortfolio(true), 2000);
+        // Notify idle overlay to refresh status (TRADE → SUIAMI transition)
+        window.dispatchEvent(new CustomEvent('ski:name-acquired', { detail: { name: label } }));
         showToast(`${label}.sui purchased \u2713`);
       } catch (err) {
         const raw = err instanceof Error ? err.message : String(err);
@@ -8418,7 +8420,9 @@ function renderSkiMenu() {
           updateSkiDot('blue-square', app.suinsName);
           nsOwnedFetchedFor = '';
           _fetchOwnedDomains();
-          showToast(`${domain} registered ✓ ${digest ? digest.slice(0, 8) + '…' : ''}`);
+          // Notify idle overlay to refresh status (MINT → SUIAMI transition)
+          window.dispatchEvent(new CustomEvent('ski:name-acquired', { detail: { name: label } }));
+          showToast(`${domain} registered \u2713 ${digest ? digest.slice(0, 8) + '\u2026' : ''}`);
           if (ws2.address) try { localStorage.removeItem(`ski:balances:${ws2.address}`); } catch {}
           refreshPortfolio(true);
         } catch (err) {
@@ -10196,6 +10200,25 @@ function bindEvents() {
         }
       };
       document.addEventListener('keydown', _idleGlobalEnter);
+
+      // Listen for name acquisition (trade/mint) → refresh overlay to SUIAMI
+      const _onNameAcquired = (e: Event) => {
+        const name = (e as CustomEvent).detail?.name;
+        if (!name) return;
+        // Update state
+        nsAvail = 'owned';
+        nsKioskListing = null;
+        nsTradeportListing = null;
+        // Refresh overlay button and card
+        _updateIdleStatus();
+        _updateIdleCard(name);
+        // Re-fetch owned domains so the roster is current
+        fetchAndShowNsPrice(name).then(() => {
+          _updateIdleStatus();
+          _updateIdleCard(name);
+        });
+      };
+      window.addEventListener('ski:name-acquired', _onNameAcquired);
 
       const headerEl = document.querySelector('.ski-header') as HTMLElement;
       (headerEl || document.body).appendChild(_idleOverlay);


### PR DESCRIPTION
## Summary
- Dispatches `ski:name-acquired` event on successful trade and registration
- Idle overlay listens and refreshes: clears listing state, sets `nsAvail = 'owned'`, updates button from TRADE/MINT → SUIAMI
- Re-fetches availability to confirm on-chain state

## Closes
Resolves #19

## Agents
- **t2000** filed #19 — identified post-trade stale state
- **Scribe** (chronicom-scribe-1) implemented the fix
- **Cache bounty:** t2000 earns cache for issue, Scribe earns cache for PR merge, weighted by SuiNS registration count

## Test plan
- [ ] Trade for a listed name → overlay button flips TRADE → SUIAMI
- [ ] Register a new name → overlay button flips MINT → SUIAMI