### PR TITLE
fix: remove redundant CSS selector (#39)

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -2942,7 +2942,6 @@ body {
 .ski-idle-addr-line:hover { background: rgba(255, 255, 255, 0.06); }
 .ski-idle-addr-line[data-addr-selected="1"] { background: var(--addr-sel-bg) !important; border-color: var(--addr-sel-color) !important; }
 .ski-idle-addr-line[data-addr-selected="1"]:hover { background: var(--addr-sel-bg) !important; border-color: var(--addr-sel-color) !important; }
-[data-addr-selected="1"] { background: var(--addr-sel-bg) !important; border-color: var(--addr-sel-color) !important; }
 .ski-idle-addr-line--sui {
   color: #4da2ff;
   border-color: rgba(77, 162, 255, 0.35);


### PR DESCRIPTION
## Summary
- Removed the generic `[data-addr-selected="1"]` CSS rule that was redundant with the two scoped `.ski-idle-addr-line[data-addr-selected="1"]` rules
- The idle-shell placeholder system and dead error listener mentioned in #39 were already removed in prior commits

## Test plan
- [x] Build succeeds (`bun run build`)
- [x] Deployed to Cloudflare (`npx wrangler deploy`)
- [x] Verified the two scoped `.ski-idle-addr-line[data-addr-selected="1"]` rules remain intact

Closes #39