### PR TITLE
fix: guard getCrossChainStatus against wallet switch during async (#43)

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -5872,10 +5872,13 @@ function renderSkiMenu() {
   // Auto-detect dWallet on menu render (non-blocking, updates cache)
   if ((!app.btcAddress || !app.solAddress) && ws.address && !_dwalletCheckInFlight) {
     _dwalletCheckInFlight = true;
+    const _ikaQueryAddr = ws.address;
     import('./client/ika.js').then(({ getCrossChainStatus }) =>
       getCrossChainStatus(ws.address)
     ).then((status) => {
       _dwalletCheckInFlight = false;
+      // Wallet switched during query — discard stale result
+      if (getState().address !== _ikaQueryAddr) return;
       let changed = false;
       if (status.btcAddress && status.btcAddress !== app.btcAddress) {
         app.btcAddress = status.btcAddress;


### PR DESCRIPTION
## Summary
- Captures wallet address before the async `getCrossChainStatus` call and checks it hasn't changed when the response arrives
- Prevents stale IKA dWallet data (BTC/ETH/SOL addresses) from being applied to a different wallet after a switch during the in-flight query

## Test plan
- [ ] Connect wallet A (with IKA dWallet), open SKI menu, quickly switch to wallet B before the query resolves — verify wallet B does not show wallet A's cross-chain addresses
- [ ] Connect wallet with IKA dWallet, open SKI menu, let query complete normally — verify addresses populate correctly
- [ ] Simulate network error during query — verify `_dwalletCheckInFlight` resets and no localStorage is cleared