### PR TITLE
fix: revoke blob URLs on video cache reload (#40)

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -9204,6 +9204,7 @@ function render() {
 // ─── Global event bindings ───────────────────────────────────────────
 
 let _idleOverlay: HTMLElement | null = null;
+let _idleVideoBlobUrl: string | null = null;
 
 function bindEvents() {
   els.skiDot?.addEventListener('click', (e) => {
@@ -11730,14 +11731,15 @@ function bindEvents() {
           if (cached) {
             // Serve from cache — instant
             const blob = await cached.blob();
-            const url = URL.createObjectURL(blob);
-            _idleVideo.src = url;
+            if (_idleVideoBlobUrl) URL.revokeObjectURL(_idleVideoBlobUrl);
+            _idleVideoBlobUrl = URL.createObjectURL(blob);
+            _idleVideo.src = _idleVideoBlobUrl;
             _idleVideo.load();
           } else {
             // First visit — fetch, cache, and let the video load normally
             try {
               const resp = await fetch(vSrc);
-              if (resp.ok) cache.put(vSrc, resp);
+              if (resp.ok) cache.put(vSrc, resp.clone());
             } catch {}
           }
         }).catch(() => {});


### PR DESCRIPTION
## Summary
- Revoke previous blob URL via `URL.revokeObjectURL` before creating a new one each time the idle overlay opens, preventing memory leaks
- Track the current blob URL in a module-level `_idleVideoBlobUrl` variable
- Clone the response before passing to `cache.put` so the body is not consumed on first visit

## Test plan
- [ ] Open idle overlay multiple times, confirm video plays each time
- [ ] Check browser DevTools Memory tab — blob URL count should stay at 0 or 1, not grow
- [ ] First visit (empty cache): video loads normally and is cached for next time