### PR TITLE
fix(roster): resolve owned names correctly

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -9619,17 +9619,10 @@ function bindEvents() {
         let targetNames: Array<{ name: string; expirationMs: number }> = [];
         if (targetAddr) {
           try {
-            const res = await fetch('https://graphql.mainnet.sui.io/graphql', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ query: `{ address(address: "${targetAddr}") { suinsRegistrations { nodes { domain expirationTimestampMs } } } }` }),
-            });
-            const gql = await res.json() as any;
-            const nodes = gql?.data?.address?.suinsRegistrations?.nodes ?? [];
-            for (const n of nodes) {
-              const bare = (n.domain || '').replace(/\.sui$/, '').toLowerCase();
-              const expMs = parseInt(n.expirationTimestampMs || '0', 10);
-              if (bare) targetNames.push({ name: bare, expirationMs: expMs });
+            const domains = await fetchOwnedDomains(targetAddr);
+            for (const d of domains) {
+              const bare = d.name.replace(/\.sui$/, '').toLowerCase();
+              if (bare) targetNames.push({ name: bare, expirationMs: d.expirationMs ?? 0 });
             }
             targetNames.sort((a, b) => a.name.localeCompare(b.name));
           } catch {}


### PR DESCRIPTION
## Summary
- The roster panel queried `suinsRegistrations` on the GraphQL `Address` type, which **does not exist** in the Sui GraphQL schema
- The query silently returned `null`, defaulting to empty array → "No names found" for every target
- Fixed by reusing `fetchOwnedDomains()` which correctly queries `objects` filtered by `SuinsRegistration` type (same pattern used for the connected wallet's own names)

## Root cause
`suinsRegistrations` was never a valid field on the Sui GraphQL `Address` type. The correct approach is `address.objects(filter: { type: "...SuinsRegistration" })`, which is what `fetchNftDomains()` already does.

## Test plan
- [x] Build succeeds
- [x] Deployed to sui.ski
- [ ] Open sui.ski, type "brando" → click @ button → roster shows owned names with blue squares + days left
- [ ] Try other registered names → roster shows their owned names