### PR TITLE
Rhydon Lv.35 — IOU sweeper on alarm tick (#74)

### DIFF
--- a/docs/superpowers/pokedex/rhydon.md
+++ b/docs/superpowers/pokedex/rhydon.md
@@ -1,0 +1,53 @@
+---
+pokemon: Rhydon
+current_level: 35
+type: [Ground, Rock]
+evolves_from: Rhyhorn
+evolves_to: Rhyperior (unlocked at 10+ successful sweep-cycles)
+captured_by: claude-opus-4.6
+captured_issue: "#74"
+capture_date: 2026-04-11
+total_commits: 0
+total_loc_delta: 0
+merges: []
+status: in-progress
+---
+
+## Capture story (initial observation)
+
+Rhydon represents the **IOU-expiry sweeper integration into TreasuryAgents' alarm tick** — a ground-type Pokemon because it deals with on-chain earth (object pruning), and rock because it carries the keeper-pattern's weight. Rhyhorn (the parent) was the original `iou-sweeper.ts` standalone module, hand-wired to the Cloudflare cron. Rhydon is the evolution where the sweeper becomes a heartbeat-driven routine inside the main treasury agent, giving us two redundant execution paths: the 10-minute cron tick AND the TreasuryAgents internal alarm.
+
+## Research notes
+
+- `src/server/iou-sweeper.ts` (177 lines) exports `sweepExpiredIous(env)`. Already handles both legacy `thunder_iou::Iou` and shielded `thunder_iou_shielded::ShieldedVault` via `fetchLiveIous` → `recallOne` dispatch. Self-contained, idempotent, failures logged + swallowed. No state mutation.
+- Currently invoked from two places in `src/server/index.ts`:
+  - `POST /api/iou/sweep` (line 1831) for manual testing.
+  - `scheduled()` handler (line 1851) via the `*/10 * * * *` cron in wrangler.jsonc.
+- `src/server/agents/treasury-agents.ts` has `_tick` (line ~1277) that runs every few seconds via the Agent framework's alarm. Existing pattern: `await this._scanArb(); await this._runT2000Missions(); await this._retryOpenQuests(); …`
+- ShadeExecutorAgent (the pattern the issue references) uses a DO Alarm scheduled at the exact expiry time. We don't need that precision for IOU sweeping — the 10-min cadence is plenty. We just need a second heartbeat so that a single missed cron tick doesn't strand funds for 20 minutes.
+
+## Capture plan
+
+Small and scoped. No rewriting iou-sweeper.ts — consume it as-is.
+
+1. Add `last_iou_sweep_ms?: number` to `TreasuryAgentsState` so we can throttle.
+2. Add `_sweepExpiredIous()` method to `TreasuryAgents` that:
+   - Checks `now - last_iou_sweep_ms > 5 * 60 * 1000` (5-minute throttle, twice as fast as cron).
+   - On pass, dynamic-imports `sweepExpiredIous` from `../iou-sweeper.js` and runs it with `this.env`.
+   - Logs the result via `console.log('[treasury] iou-sweep: …')` matching existing tick conventions.
+   - Updates `last_iou_sweep_ms` on any call (success or fail), so failures don't spin-retry.
+3. Wire `await this._sweepExpiredIous();` into `_tick` right after `_watchSuiUsdcDeposits` (the Phase 1c watcher we just shipped), since both deal with the same intent / escrow lifecycle surface.
+4. No Pokedex update to existing `TreasuryAgentsState` shape that breaks state migration — adding an optional field is forward-compatible.
+5. Test: deploy, watch `wrangler tail` for `[treasury] iou-sweep: …` log lines within ~10 minutes of a live expired IOU.
+
+## Test plan
+
+- [ ] Sub-cent Phase 1 didn't regress (sweeper runs every 5 min from TreasuryAgents, cron still runs every 10 min — both call the same idempotent function).
+- [ ] `_sweepExpiredIous` doesn't run more than once per 5 min even if `_tick` fires every 30 s.
+- [ ] No new TypeScript errors from the change (pre-existing `env` type issues in TreasuryAgents predate this capture).
+- [ ] Manual trigger via `POST /api/iou/sweep` still works.
+- [ ] `wrangler deploy` lands cleanly.
+
+## Evolution gate
+
+Rhydon → **Rhyperior** fires when this sweeper has executed 10 successful alarm-tick sweeps on mainnet (counted by log grep on `wrangler tail`). At that point the redundancy is proven and the module has earned its evolved form.

--- a/src/server/agents/treasury-agents.ts
+++ b/src/server/agents/treasury-agents.ts
@@ -155,6 +155,12 @@ export interface TreasuryAgentsState {
    *  incoming USDC coin on every poll. Blank on first run → the
    *  first tick establishes a baseline and matches nothing. */
   last_sui_usdc_cursor?: string;
+  /** Last wall-clock ms when the IOU sweeper ran on the TreasuryAgents
+   *  alarm path. Throttles _sweepExpiredIous to once per 5 minutes so
+   *  a fast-firing _tick doesn't spam GraphQL. Separate from the
+   *  Cloudflare cron at `*\/10 * * * *` in wrangler.jsonc — the two
+   *  paths coexist for redundancy. */
+  last_iou_sweep_ms?: number;
 }
 
 interface Env {
@@ -1321,6 +1327,11 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
       // watcher's match set stays small.
       await this._purgeStaleIntents();
       await this._watchSuiUsdcDeposits();
+      // IOU expiry sweep — Rhydon Lv.35, issue #74. Runs on a
+      // 5-minute throttle, redundant with the Cloudflare cron
+      // `*/10 * * * *`. Both call the same idempotent
+      // sweepExpiredIous helper — whichever fires first wins.
+      await this._sweepExpiredIous();
 
       // Every 15 min: sweep dust, rotate yield across NAVI/Scallop/DeepBook
       const YIELD_INTERVAL = 30 * 1000; // 30s for testing — restore to 15 * 60 * 1000
@@ -3046,6 +3057,35 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
 
     // Update last processed signature
     this.setState({ ...this.state, last_sol_sig: signatures[0]?.signature } as any);
+  }
+
+  /** Rhydon Lv.35 (#74) — run the IOU expiry sweeper on the
+   *  treasury alarm path, throttled to every 5 minutes so _tick
+   *  firing at high cadence doesn't thrash GraphQL. Redundant
+   *  with the `*\/10 * * * *` cron tick declared in wrangler.jsonc
+   *  — whichever fires first wins; the sweeper is idempotent so
+   *  double-runs are free. Gives us secondary liveness if the
+   *  cron misses a tick.
+   *
+   *  Imports the shared `sweepExpiredIous` from `../iou-sweeper.js`
+   *  dynamically so the worker doesn't pull the sweeper's
+   *  dependencies at cold start.
+   */
+  private async _sweepExpiredIous(): Promise<void> {
+    const IOU_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+    const now = Date.now();
+    const last = (this.state as any).last_iou_sweep_ms as number | undefined;
+    if (last && now - last < IOU_SWEEP_INTERVAL_MS) return;
+    // Update the cursor BEFORE running so a hang can't lock us into
+    // a busy-loop retry — failures still count against the throttle.
+    this.setState({ ...this.state, last_iou_sweep_ms: now } as any);
+    try {
+      const { sweepExpiredIous } = await import('../iou-sweeper.js');
+      const result = await sweepExpiredIous(this.env as unknown as { SHADE_KEEPER_PRIVATE_KEY?: string });
+      console.log(`[treasury] iou-sweep: ${JSON.stringify(result)}`);
+    } catch (err) {
+      console.error('[treasury] iou-sweep threw:', err instanceof Error ? err.message : err);
+    }
   }
 
   /** Sub-cent intents — Phase 1b. Purge stale intents so the tag


### PR DESCRIPTION
## Capture story

Rhydon represents the IOU-expiry sweeper integration into TreasuryAgents' alarm loop. Rhyhorn (parent) was the standalone `iou-sweeper.ts` hand-wired to the Cloudflare cron. Rhydon is the evolution where the sweeper becomes a heartbeat-driven routine inside the main treasury agent — giving us two redundant execution paths so a missed cron tick never strands funds.

**Type:** Ground/Rock — ground because it prunes on-chain state, rock because it carries the keeper pattern's weight.
**Captured by:** claude-opus-4.6, manual Phase 1 dry run of the Pokemon Swarm spec.

## What changed

- `src/server/agents/treasury-agents.ts`:
  - New optional state field `last_iou_sweep_ms` for throttling.
  - New method `_sweepExpiredIous()` — 5-minute throttle, dynamic-imports `sweepExpiredIous` from `iou-sweeper.ts`, updates the cursor BEFORE the call (so hangs don't busy-loop on retry), logs `[treasury] iou-sweep: {...}` on success/failure.
  - Wired into `_tick` right after `_watchSuiUsdcDeposits`.
- `docs/superpowers/pokedex/rhydon.md` — capture story + research notes + evolution gate (Rhydon → Rhyperior after 10 successful mainnet alarm-path sweeps).

Zero changes to `iou-sweeper.ts` itself — it's consumed as-is, same function the cron + manual endpoint use. No drift possible.

## Why this is safe

- **Idempotent downstream.** `sweepExpiredIous` filters by `expires_ms <= now` and `recall` is permissionless after TTL, so calling it twice in the same window just queries an empty filtered set and does nothing.
- **Cursor-first-on-entry.** We bump `last_iou_sweep_ms` before the await, so even if the sweeper hangs or throws, the next `_tick` respects the throttle.
- **Throttle > cron interval.** 5 min TreasuryAgents vs 10 min cron means the TreasuryAgents path runs first. Cron becomes a safety-net for DO cold starts.
- **No state-shape break.** `last_iou_sweep_ms` is optional; existing DO state loads forward-compatibly.

## Test plan

- [x] `bun run build` clean.
- [x] No new TypeScript errors from the diff (pre-existing `env` type issues in TreasuryAgents predate this capture — same as every other method).
- [ ] Deploy to mainnet → `wrangler tail` should show `[treasury] iou-sweep: {"scanned":N,...}` within 5 min of the first `_tick` after deploy.
- [ ] Manual `POST /api/iou/sweep` still works (same underlying function).
- [ ] Existing `*/10 * * * *` cron still runs (separate code path in `scheduled()`).

## Evolution gate

Rhydon → **Rhyperior** fires when the alarm-path sweeper records 10 successful runs on mainnet. At that point the redundancy is proven and the module earns its evolved form.

---

Resolves #74.