### PR TITLE
ci: Klefki Lv.30 — npm publish preflight for fail-fast token diagnostics

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,6 +26,50 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # ── Klefki Lv.30 (#109) — fail fast on broken token ─────────────
+      # Run BEFORE install/build so we don't waste 2 minutes of CI on
+      # a token that can't publish. The real npm error on E404 is
+      # misleading ("package not in this registry" when the package
+      # clearly exists); these checks surface the actual root cause.
+      - name: NPM token preflight
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+        run: |
+          set -e
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NODE_AUTH_TOKEN secret is empty or missing. Fix: gh secret set NODE_AUTH_TOKEN --repo arbuthnot-eth/.SKI"
+            exit 1
+          fi
+          echo "Checking npm whoami..."
+          if ! WHO=$(npm whoami 2>&1); then
+            echo "::error::npm whoami failed. Token is invalid/expired/revoked. Root cause: $WHO"
+            echo "::error::Fix: create a new Granular Access Token at https://www.npmjs.com/settings/<user>/tokens with Read and write + sui.ski in the Packages list, then update NODE_AUTH_TOKEN."
+            exit 1
+          fi
+          echo "npm whoami: $WHO"
+          echo ""
+          echo "Checking that token can publish to sui.ski..."
+          # npm access list packages returns the packages this token can access.
+          # Grep for the exact package name to catch wrong-scope tokens.
+          if ! PKGS=$(npm access list packages 2>&1); then
+            echo "::warning::npm access list packages failed — continuing anyway, publish will tell us the real answer. Output: $PKGS"
+          else
+            if ! echo "$PKGS" | grep -q '"sui.ski"'; then
+              echo "::error::Token does not have access to sui.ski. Granular tokens must explicitly include the package in their Packages list."
+              echo "::error::Current accessible packages:"
+              echo "$PKGS"
+              echo "::error::Fix: https://www.npmjs.com/settings/$WHO/tokens → Edit token → add sui.ski to Packages, OR regenerate as a Classic Automation token."
+              exit 1
+            fi
+            ACCESS=$(echo "$PKGS" | grep '"sui.ski"')
+            if echo "$ACCESS" | grep -q '"read-only"'; then
+              echo "::error::Token has READ-ONLY access to sui.ski. Need Read and write to publish."
+              echo "::error::Fix: https://www.npmjs.com/settings/$WHO/tokens → Edit token → change sui.ski to Read and write."
+              exit 1
+            fi
+            echo "Token has write access to sui.ski. Proceeding."
+          fi
+
       - name: Install dependencies
         run: bun install
 


### PR DESCRIPTION
## Summary
- Adds a preflight step to the \`Publish npm Package\` workflow that runs BEFORE install/build
- Checks \`NODE_AUTH_TOKEN\` is set, \`npm whoami\` succeeds, and the token has write access to \`sui.ski\`
- Emits \`::error::\` annotations with exact remediation steps on failure

Refs #109.

## Context

Every push to master since 2026-04-11 has failed the publish workflow with:

\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/sui.ski - Not found
npm error 404  'sui.ski@3.1.43' is not in this registry.
\`\`\`

The 404 is misleading — \`sui.ski\` does exist on the registry (\`curl https://registry.npmjs.org/sui.ski\` → 200). The actual cause is that \`NODE_AUTH_TOKEN\` was rotated on 2026-04-09 14:25 UTC and the new token doesn't have write access to \`sui.ski\` (likely a granular token without the package in its allowed Packages list).

The real npm publish error only fires AFTER 2 minutes of CI (install + build + bump + provenance). This preflight catches it in ~5 seconds.

## What the preflight does

1. **Check secret present** — \`NODE_AUTH_TOKEN\` must be non-empty, else fail with \`gh secret set\` fix command
2. **\`npm whoami\`** — token must be valid, else fail with "regenerate at npmjs.com/settings/\<user\>/tokens"
3. **\`npm access list packages\`** — token must include \`sui.ski\` in its accessible-packages list (catches the granular-token-wrong-scope case that's biting us right now)
4. **Access level check** — if sui.ski is listed but read-only, fail with "change to Read and write"

On any failure the job emits \`::error::\` annotations pointing at the exact fix, including the npm settings URL and the gh CLI command to update the secret.

## Test plan

- [ ] Merge this PR
- [ ] Push triggers workflow
- [ ] Preflight should fire first
- [ ] If the token is still broken (likely), preflight fails in ~5s with a clear error message telling @arbuthnot-eth exactly what to do
- [ ] After fixing the token per #109, re-run the workflow and it should pass

## Does NOT fix the current incident
This PR only improves diagnostics. The token itself still needs to be re-minted by the repo owner — see #109 for the actual fix steps. This PR ensures the next token rotation fails loudly instead of silently.