### PR TITLE
chore(release): sync pkg to 3.1.43 + harden publish pipeline ordering

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -94,11 +94,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
-      - name: Create GitHub Release
-        run: gh release create "v${{ steps.version.outputs.value }}" --title "v${{ steps.version.outputs.value }}" --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      # Commit the version bump + tag BEFORE creating the release so
+      # that a failed release step can never leave the git state out
+      # of sync with npm (which happened on 2026-04-09 and blocked
+      # every subsequent run — v3.1.43 tag existed but pointed at the
+      # v3.1.42 bump commit, so `gh release create v3.1.43` 422'd).
       - name: Commit version bump and tag
         run: |
           git checkout -- .npmrc 2>/dev/null || true
@@ -106,3 +106,17 @@ jobs:
           git commit -m "chore(release): v${{ steps.version.outputs.value }} [skip ci]"
           git tag "v${{ steps.version.outputs.value }}"
           git push origin HEAD:master --follow-tags
+
+      # Idempotent: if a release with this tag already exists (from a
+      # partial earlier run or manual cleanup), skip and keep going
+      # instead of failing the whole workflow post-publish.
+      - name: Create GitHub Release
+        run: |
+          VERSION="v${{ steps.version.outputs.value }}"
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists — skipping create."
+          else
+            gh release create "$VERSION" --title "$VERSION" --generate-notes
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sui.ski",
-  "version": "3.1.42",
+  "version": "3.1.43",
   "description": ".Sui Key-In — .SKI once, everywhere.",
   "type": "module",
   "main": "public/dist/ski.js",


### PR DESCRIPTION
## Summary
- Syncs \`package.json\` version to \`3.1.43\` (matches what is now live on npm)
- Reorders publish workflow so commit/tag runs BEFORE release creation
- Makes \`Create GitHub Release\` idempotent so partial failures don't wedge the pipeline

Refs #109.

## Root cause of the stuck pipeline

On 2026-04-09 the publish workflow hit a race:

1. A successful run published \`sui.ski@3.1.42\`, created release \`v3.1.42\`, and pushed tag \`v3.1.42\`
2. Something (either a follow-on push or manual intervention) ended up creating a GitHub release \`v3.1.43\` and git tag \`v3.1.43\` pointing at commit \`91d1d97f\` — which is actually the \`chore(release): v3.1.42 [skip ci]\` commit, not any 3.1.43 content
3. Over the next two days, every run failed at the preflight due to a rotated token (#109)
4. After the token was fixed and the Klefki preflight let the run continue, it successfully published \`sui.ski@3.1.43\` to npm but then \`gh release create v3.1.43\` hit HTTP 422 \"Release.tag_name already exists\" because the stale 4/9 release was still there
5. The final \`Commit version bump and tag\` step was skipped (dependent on the release step), so \`package.json\` locally stayed at \`3.1.42\` while npm moved to \`3.1.43\`

## Fix

### 1. Sync \`package.json\` to \`3.1.43\`
Without this, the next workflow run would bump \`3.1.42 → 3.1.43\` and hit \`E409 cannot publish over existing version\`.

### 2. Reorder workflow steps
Move \`Commit version bump and tag\` BEFORE \`Create GitHub Release\`. Now the git state is in sync with npm *before* the release step runs. If the release step fails for any reason, the next push naturally bumps to the next patch version instead of retrying the same one.

### 3. Idempotent release creation
\`\`\`bash
if gh release view \"$VERSION\" >/dev/null 2>&1; then
  echo \"Release $VERSION already exists — skipping create.\"
else
  gh release create \"$VERSION\" --title \"$VERSION\" --generate-notes
fi
\`\`\`

A release created manually or left over from a prior partial run no longer blocks the workflow.

## Out-of-band cleanup (already done before this PR)
- \`gh release delete v3.1.43 --yes --repo arbuthnot-eth/.SKI\`
- \`git push origin :refs/tags/v3.1.43\`

## Test plan
- [ ] Merge this PR
- [ ] Merge triggers a workflow run
- [ ] Klefki preflight passes (token is fresh)
- [ ] Bumps \`3.1.43 → 3.1.44\`, publishes, commits, tags, creates release \`v3.1.44\`
- [ ] Verify \`curl -s https://registry.npmjs.org/sui.ski/latest | jq .version\` returns \`3.1.44\`