### PR TITLE
ci: annotated tags + explicit tag push in publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -101,11 +101,23 @@ jobs:
       # v3.1.42 bump commit, so `gh release create v3.1.43` 422'd).
       - name: Commit version bump and tag
         run: |
+          set -e
+          VERSION="v${{ steps.version.outputs.value }}"
           git checkout -- .npmrc 2>/dev/null || true
           git add package.json bun.lock
-          git commit -m "chore(release): v${{ steps.version.outputs.value }} [skip ci]"
-          git tag "v${{ steps.version.outputs.value }}"
-          git push origin HEAD:master --follow-tags
+          git commit -m "chore(release): $VERSION [skip ci]"
+          # Annotated tag (-a -m) instead of lightweight. `git push
+          # --follow-tags` ONLY pushes annotated tags, not lightweight
+          # ones — a lightweight tag here will silently vanish and the
+          # 'Create GitHub Release' step will fail with
+          # "tag exists locally but has not been pushed".
+          git tag -a "$VERSION" -m "$VERSION"
+          # Belt-and-suspenders: push the branch first, then push the
+          # tag explicitly as a second operation. This way the tag
+          # lands even if --follow-tags semantics change or the tag
+          # type accidentally reverts to lightweight in the future.
+          git push origin HEAD:master
+          git push origin "refs/tags/$VERSION"
 
       # Idempotent: if a release with this tag already exists (from a
       # partial earlier run or manual cleanup), skip and keep going


### PR DESCRIPTION
## Summary
- Replace lightweight \`git tag\` with annotated \`git tag -a\`
- Split \`git push --follow-tags\` into separate branch push + explicit tag push
- Fixes the silent-tag-drop bug that made 'Create GitHub Release' fail for v3.1.44

## The bug

\`git push --follow-tags\` documents: "Push all the refs that would be pushed without this option, and also push annotated tags in refs/tags that are missing from the remote but are pointing at commit-ish that are reachable from the refs being pushed."

Note: **annotated** tags only. Lightweight tags are silently ignored.

The workflow used \`git tag "v$VERSION"\` which creates a lightweight tag, so \`--follow-tags\` did nothing for the tag. The commit bump pushed fine but the tag was left behind on the GH Actions runner filesystem. Then 'Create GitHub Release' saw the local tag present, tried to reference it, and got:

\`\`\`
tag v3.1.44 exists locally but has not been pushed to arbuthnot-eth/.SKI,
please push it before continuing or specify the \`--target\` flag to create a new tag
\`\`\`

## The fix

1. \`git tag -a "$VERSION" -m "$VERSION"\` — annotated tag with a trivial message. Annotated tags are the git convention for releases anyway.
2. \`git push origin HEAD:master\` then \`git push origin "refs/tags/$VERSION"\` as two explicit operations. Belt and suspenders — if anyone reverts to lightweight tags in the future, the explicit tag push still lands it.

## Out-of-band cleanup already done
- \`git tag v3.1.44 75a5f6b && git push origin v3.1.44\` — pushed the missing tag from the previous run
- \`gh release create v3.1.44 --title v3.1.44 --generate-notes\` — created the missing release

## Test plan
- [ ] Merge this PR
- [ ] (Merge alone won't trigger workflow due to GITHUB_TOKEN exclusion; need to \`gh workflow run publish-npm.yml --repo arbuthnot-eth/.SKI --ref master\` after merge)
- [ ] Dispatched run bumps to 3.1.45
- [ ] Publishes to npm
- [ ] Tag v3.1.45 lands on remote
- [ ] Release v3.1.45 created
- [ ] \`curl https://registry.npmjs.org/sui.ski/latest | jq .version\` returns 3.1.45