### PR TITLE
feat(redeem): Shelgon Lv.45 stage-1 scaffold — shadow-DKG stub

### DIFF
--- a/src/server/agents/treasury-agents.ts
+++ b/src/server/agents/treasury-agents.ts
@@ -269,7 +269,7 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
     // All mutating requests from the Worker must include x-treasury-auth.
     // Read-only endpoints (status, squid-stats, shade-list, deposit-status,
     // deposit-addresses, quest-bounties) are exempt.
-    const readOnlyParams = ['cache-state', 'squid-stats', 'shade-list', 'deposit-status', 'deposit-addresses', 'quest-bounties', 'redeem-solana-status', 'redeem-solana-resolve', 'redeem-solana-list'];
+    const readOnlyParams = ['cache-state', 'squid-stats', 'shade-list', 'deposit-status', 'deposit-addresses', 'quest-bounties', 'redeem-solana-status', 'redeem-solana-resolve', 'redeem-solana-list', 'shadow-dkg-status'];
     const isReadOnly = readOnlyParams.some(p => url.searchParams.has(p));
     const isWebSocket = request.headers.get('upgrade') === 'websocket';
     if (!isReadOnly && !isWebSocket && !this.verifyInternalAuth(request)) {
@@ -346,21 +346,132 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
     // Gastly is pure bookkeeping + API surface so the UI (Haunter) and
     // execution layer (Gengar) can build on a stable contract.
 
-    // redeem-solana-resolve — pre-flight Roster lookup for a Sui recipient
-    // address. Returns whether a Solana dWallet exists for this recipient
-    // (shadow or user-owned). For Gastly, always returns `provisioned:
-    // false`. Shelgon wires the real lookup against the SUIAMI Roster.
+    // ── Shelgon Lv.45 scaffold (#104) — shadow-DKG provisioning ─────
+    //
+    // STAGE 1 (this commit): STUB — generates a deterministic stub
+    // Solana pubkey for any Sui recipient and writes it to the
+    // shadow_dwallets state slot. The stub is INERT: it is not a
+    // valid Solana address that can receive funds; it's a placeholder
+    // for API/UI wiring while the real IKA DKG flow is designed and
+    // reviewed.
+    //
+    // STAGE 2 (follow-up PR): replaces the stub pubkey with a real
+    // IKA dWallet provisioned via a keeper-runs-alone variant of
+    // buildProvisionTx (src/server/ika-provision.ts). Requires:
+    //   - ED25519 curve (Solana) — existing code uses SECP256K1 for BTC/ETH
+    //   - User share encrypted to recipient's Sui Ed25519 pubkey from
+    //     moment zero (noble-curves sealed_box or libsodium crypto_box_seal)
+    //   - DWalletCap gated on recipient sig OR (agent half + IKA network)
+    //
+    // Stage 2 is blocked behind design review per the mainnet review
+    // gate. DO NOT ship real DKG code in this scaffold.
+
+    // shadow-dkg-provision — create or fetch a shadow dWallet stub
+    // for a recipient Sui address. Idempotent: repeat calls return
+    // the existing record if one already exists.
+    if ((url.pathname.endsWith('/shadow-dkg-provision') || url.searchParams.has('shadow-dkg-provision')) && request.method === 'POST') {
+      try {
+        const body = await request.json() as { recipient: string };
+        if (!body.recipient) {
+          return new Response(JSON.stringify({ error: 'recipient required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+        const shadows = ((this.state as any).shadow_dwallets ?? []) as Array<Record<string, unknown>>;
+        const existing = shadows.find(s => s.recipient === body.recipient);
+        if (existing) {
+          return new Response(JSON.stringify({
+            recipient: body.recipient,
+            solPubkey: existing.solPubkey,
+            via: existing.via,
+            provisioned: true,
+            createdAt: existing.createdAt,
+            stage: existing.stage,
+            deduplicated: true,
+          }), { headers: { 'content-type': 'application/json' } });
+        }
+        // Stage-1 stub: derive a deterministic placeholder pubkey from
+        // sha256(recipient || 'shelgon-v1-stub'). Base58-encoded to look
+        // like a Solana pubkey in the UI. DOES NOT correspond to any
+        // real Solana keypair — sending funds to this address will burn
+        // them. Stage 2 replaces with a real IKA-derived Ed25519 pubkey.
+        const seedBytes = new TextEncoder().encode(body.recipient + ':shelgon-v1-stub');
+        const hashBuf = await crypto.subtle.digest('SHA-256', seedBytes);
+        const hashArr = Array.from(new Uint8Array(hashBuf));
+        // Simple base58 encoding (Bitcoin alphabet) — not production-grade
+        // but sufficient for the stub to look the part in the UI.
+        const alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+        let num = 0n;
+        for (const b of hashArr) num = (num << 8n) | BigInt(b);
+        let encoded = '';
+        while (num > 0n) {
+          const rem = Number(num % 58n);
+          num = num / 58n;
+          encoded = alphabet[rem] + encoded;
+        }
+        const solPubkey = `SKIstub${encoded.slice(0, 37)}`;
+        const now = Date.now();
+        const record = {
+          recipient: body.recipient,
+          solPubkey,
+          via: 'shadow-stub' as const,
+          stage: 1,
+          createdAt: now,
+          updatedAt: now,
+          realDkgPending: true,
+        };
+        shadows.push(record);
+        this.setState({ ...this.state, shadow_dwallets: shadows } as any);
+        console.log(`[TreasuryAgents] Shelgon stub provisioned: ${body.recipient.slice(0, 10)}… → ${solPubkey} (stage 1 INERT)`);
+        return new Response(JSON.stringify({
+          recipient: body.recipient,
+          solPubkey,
+          via: 'shadow-stub',
+          provisioned: true,
+          stage: 1,
+          createdAt: now,
+          warning: 'Stage 1 stub — pubkey is a placeholder, not a valid Solana address. Sending funds here will burn them. Stage 2 (real IKA DKG) is pending design review.',
+        }), { status: 202, headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 400, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // shadow-dkg-status — lookup by recipient (read-only)
+    if ((url.pathname.endsWith('/shadow-dkg-status') || url.searchParams.has('shadow-dkg-status')) && request.method === 'GET') {
+      const recipient = url.searchParams.get('recipient') || '';
+      if (!recipient) return new Response(JSON.stringify({ error: 'recipient query param required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+      const shadows = ((this.state as any).shadow_dwallets ?? []) as Array<Record<string, unknown>>;
+      const record = shadows.find(s => s.recipient === recipient);
+      if (!record) {
+        return new Response(JSON.stringify({ recipient, provisioned: false, via: 'none' }), { headers: { 'content-type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({ ...record, provisioned: true }), { headers: { 'content-type': 'application/json' } });
+    }
+
+    // redeem-solana-resolve — pre-flight lookup for a Sui recipient
+    // address. Reads the shadow_dwallets state slot populated by
+    // shadow-dkg-provision. Returns whether a Solana dWallet (stub or
+    // real) exists for this recipient.
     if ((url.pathname.endsWith('/redeem-solana-resolve') || url.searchParams.has('redeem-solana-resolve')) && request.method === 'GET') {
       const recipient = url.searchParams.get('recipient') || '';
       if (!recipient) return new Response(JSON.stringify({ error: 'recipient query param required' }), { status: 400, headers: { 'content-type': 'application/json' } });
-      // Scaffolding stub: Shelgon Lv.45 replaces this with a real lookup
-      // against ROSTER_PKG + sol@<recipient> key resolution.
+      const shadows = ((this.state as any).shadow_dwallets ?? []) as Array<Record<string, unknown>>;
+      const record = shadows.find(s => s.recipient === recipient);
+      if (!record) {
+        return new Response(JSON.stringify({
+          recipient,
+          provisioned: false,
+          solPubkey: null,
+          via: 'none',
+          hint: 'POST /api/shadow-dkg/provision with { recipient } to create a stub dWallet',
+        }), { headers: { 'content-type': 'application/json' } });
+      }
       return new Response(JSON.stringify({
         recipient,
-        provisioned: false,
-        solPubkey: null,
-        via: 'none',
-        note: 'Gastly scaffold — Shelgon Lv.45 (#104) will add real Roster lookup and shadow-DKG provisioning',
+        provisioned: true,
+        solPubkey: record.solPubkey,
+        via: record.via,
+        stage: record.stage,
+        createdAt: record.createdAt,
       }), { headers: { 'content-type': 'application/json' } });
     }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1798,6 +1798,52 @@ app.get('/api/redeem/solana/status', async (c) => {
   }
 });
 
+// ── Shelgon Lv.45 scaffold (#104) — shadow-DKG provisioning ─────────
+//
+// Two endpoints forwarded to the TreasuryAgents DO.
+//
+// Stage 1 (this scaffold): returns a deterministic STUB pubkey for
+// any Sui recipient. The stub is INERT — it's not a valid Solana
+// address, sending funds to it will burn them. Gastly's /resolve
+// endpoint reads from the same DO state slot so the API contract is
+// real even though the dWallet isn't.
+//
+// Stage 2 (follow-up PR): replaces the stub with a real IKA-derived
+// Ed25519 dWallet via a keeper-runs-alone variant of buildProvisionTx.
+// Gated behind design review per the mainnet review gate.
+
+app.post('/api/shadow-dkg/provision', async (c) => {
+  try {
+    const body = await c.req.json() as { recipient: string };
+    if (!body.recipient) return c.json({ error: 'recipient required' }, 400);
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/?shadow-dkg-provision', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+      body: JSON.stringify(body),
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+app.get('/api/shadow-dkg/status', async (c) => {
+  try {
+    const recipient = c.req.query('recipient') || '';
+    if (!recipient) return c.json({ error: 'recipient query param required' }, 400);
+    const res = await authedTreasuryStub(c).fetch(new Request(`https://treasury-do/?shadow-dkg-status&recipient=${encodeURIComponent(recipient)}`, {
+      headers: { 'x-partykit-room': 'treasury' },
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
 app.get('/api/redeem/solana/list', async (c) => {
   try {
     const recipient = c.req.query('recipient') || '';


### PR DESCRIPTION
## Summary
- Two new \`/api/shadow-dkg/*\` endpoints forwarded to TreasuryAgents DO
- \`shadow_dwallets\` state slot stores provisioning records
- Gastly's \`redeem-solana-resolve\` rewired to read from real state
- Stage 1 is a deterministic INERT stub pubkey, not a real Solana address

Evolves half of #104 (stage 1). Stage 2 (real IKA DKG) is a follow-up PR.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| POST | \`/api/shadow-dkg/provision\` | Create-or-fetch a shadow dWallet stub for a Sui recipient |
| GET  | \`/api/shadow-dkg/status?recipient=<sui>\` | Lookup by recipient Sui address |
| GET  | \`/api/redeem/solana/resolve?recipient=<sui>\` | Rewired to read from \`shadow_dwallets\` |

## The stub IS inert

The Stage 1 pubkey is generated as:

\`\`\`
sha256(recipient_sui_addr + ':shelgon-v1-stub')
  -> base58 encode
  -> prefix with 'SKIstub'
\`\`\`

It looks like a Solana address in a UI but **has no corresponding keypair**. Sending funds to it will burn them. The response body includes a \`warning\` field that surfaces this loudly to any consumer.

This is deliberate: Stage 1 exists so Haunter (#102) and Gengar (#103) can be developed against a real API contract while the real IKA DKG design is under review. Any code path that tries to actually send funds to a stub pubkey should fail visibly — the 'SKIstub' prefix makes that trivial to assert on.

## Stage 2 (not in this PR)

Replaces the stub with a real IKA-derived Ed25519 dWallet via a keeper-runs-alone variant of \`buildProvisionTx\` in \`src/server/ika-provision.ts\`. Stage 2 requires:

- \`Curve.ED25519\` support (existing code uses \`SECP256K1\` for BTC/ETH)
- User share encrypted to recipient's Sui Ed25519 pubkey from moment zero
- \`DWalletCap\` gated on recipient sig OR (agent half + IKA network)

Gated behind agent review + human approval per the mainnet review gate.

## Test plan (all validated live on dotski)
- [x] \`GET /api/redeem/solana/resolve?recipient=<brando>\` → \`provisioned: false\` with hint
- [x] \`POST /api/shadow-dkg/provision\` with brando → stub pubkey + warning, HTTP 202
- [x] \`GET /api/redeem/solana/resolve?recipient=<brando>\` → \`provisioned: true\`, same pubkey, \`via: 'shadow-stub'\`, stage 1
- [x] \`POST /api/shadow-dkg/provision\` repeat → \`deduplicated: true\`, same pubkey (idempotent)
- [x] \`GET /api/shadow-dkg/status?recipient=<brando>\` → full record with \`realDkgPending: true\`

## What this does NOT do
- Does not touch any mainnet path
- Does not sign any transaction
- Does not move any funds
- Does not run any IKA DKG ceremony
- Does not import \`@ika.xyz/sdk\` in this code path