### PR TITLE
fix: Snorunt + Drowzee — unstick SOL deposits + correct listing-price error

### DIFF
--- a/src/server/agents/treasury-agents.ts
+++ b/src/server/agents/treasury-agents.ts
@@ -795,6 +795,183 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
     }
 
     // Manual rescan — recovery for missed deposits
+    // Snorunt Lv.30 — directly attest a SOL-chain collateral delta.
+    // Writes to the 'SOL' asset key so it doesn't collide with the
+    // Sui-side 'SUI' key (which attestLiveCollateral owns). This is
+    // how cross-chain deposits should have been routed all along.
+    if (url.pathname.endsWith('/attest-sol-collateral') && request.method === 'POST') {
+      try {
+        const body = await request.json() as { valueUsdCents: number };
+        if (!body.valueUsdCents || body.valueUsdCents <= 0) {
+          return new Response(JSON.stringify({ error: 'valueUsdCents required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+        if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return new Response(JSON.stringify({ error: 'no keeper' }), { status: 400 });
+        const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+        const ultronAddr = normalizeSuiAddress(keypair.getPublicKey().toSuiAddress());
+        const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
+        // cents -> 9-dec USD mist: cents * 10^7
+        const valueMist = BigInt(body.valueUsdCents) * 10_000_000n;
+        const tx = new Transaction();
+        tx.setSender(ultronAddr);
+        tx.moveCall({
+          package: TreasuryAgents.IUSD_PKG,
+          module: 'iusd',
+          function: 'update_collateral',
+          arguments: [
+            tx.object(TreasuryAgents.IUSD_TREASURY),
+            tx.pure.vector('u8', Array.from(new TextEncoder().encode('SOL'))),
+            tx.pure.vector('u8', Array.from(new TextEncoder().encode('solana'))),
+            tx.pure.address('0x0000000000000000000000000000000000000000000000000000000000000000'),
+            tx.pure.u64(valueMist),
+            tx.pure.u8(0),
+            tx.object('0x6'),
+          ],
+        });
+        const txBytes = await tx.build({ client: transport as never });
+        const sig = await keypair.signTransaction(txBytes);
+        const digest = await this._submitTx(txBytes, sig.signature);
+        return new Response(JSON.stringify({ digest, asset: 'SOL', valueMist: String(valueMist), humanUsd: `$${body.valueUsdCents / 100}` }), { headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // Snorunt Lv.30 — manually dispatch a known Solana deposit by sig.
+    // Unsticks deposits whose getSignaturesForAddress RPC returns empty
+    // from the worker even though the tx is real. Only trusts the caller
+    // because authedTreasuryStub's x-treasury-auth gate.
+    if (url.pathname.endsWith('/force-dispatch-sol') && request.method === 'POST') {
+      try {
+        const body = await request.json() as { sig: string; lamports: number; suiAddress: string };
+        if (!body.sig || !body.lamports || !body.suiAddress) {
+          return new Response(JSON.stringify({ error: 'sig, lamports, suiAddress required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+        const tag = body.lamports % 1000000;
+        const intents = ((this.state as any).deposit_intents ?? []) as Array<Record<string, any>>;
+        const match = intents.find(i => i.status === 'pending' && i.tag === tag && i.suiAddress === body.suiAddress);
+        if (!match) {
+          return new Response(JSON.stringify({
+            error: 'no matching pending intent',
+            tag,
+            pendingCount: intents.filter(i => i.status === 'pending').length,
+            pendingTags: intents.filter(i => i.status === 'pending').map(i => ({ tag: i.tag, sui: i.suiAddress?.slice(0, 10) })),
+          }), { status: 404, headers: { 'content-type': 'application/json' } });
+        }
+        const solPrice = await this._fetchSolPrice();
+        const solValue = (body.lamports / 1e9) * (solPrice || 85);
+        await this._dispatchMatchedIntent(match, {
+          usdValue: solValue,
+          sourceDigest: body.sig,
+          sourceChain: 'sol',
+        });
+        return new Response(JSON.stringify({
+          ok: true,
+          tag,
+          solValue,
+          dispatched: 'see _dispatchMatchedIntent logs',
+        }), { headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err), stack: (err as Error)?.stack?.slice(0, 500) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // Snorunt Lv.30 — debug dump of what _watchSolDeposits sees.
+    if (url.pathname.endsWith('/debug-sol-watch') && request.method === 'POST') {
+      try {
+        if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return new Response(JSON.stringify({ error: 'no keeper' }), { status: 400 });
+        const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+        const solAddr = toBase58(keypair.getPublicKey().toRawBytes());
+        const intents = ((this.state as any).deposit_intents ?? []) as Array<Record<string, any>>;
+        const pending = intents.filter(i => i.status === 'pending');
+        const result: any = {
+          solAddr,
+          pendingCount: pending.length,
+          pendingTags: pending.map(p => ({ tag: p.tag, suiAddress: p.suiAddress?.slice(0, 10), created: p.created })),
+          lastSolSig: (this.state as any).last_sol_sig ?? null,
+        };
+
+        const SOL_RPCS = [
+          ...(this.env.HELIUS_API_KEY ? [`https://mainnet.helius-rpc.com/?api-key=${this.env.HELIUS_API_KEY}`] : []),
+          'https://api.mainnet-beta.solana.com',
+        ];
+
+        let signatures: Array<{ signature: string; blockTime: number }> = [];
+        for (const rpc of SOL_RPCS) {
+          try {
+            const r = await fetch(rpc, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                jsonrpc: '2.0', id: 1,
+                method: 'getSignaturesForAddress',
+                params: [solAddr, { limit: 10 }],
+              }),
+              signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            });
+            const d = await r.json() as any;
+            if (d.result?.length) { signatures = d.result; result.rpcUsed = rpc.replace(/key=.*/, 'key=***'); break; }
+          } catch { /* try next */ }
+        }
+        result.sigCount = signatures.length;
+        result.sigs = signatures.map(s => s.signature.slice(0, 20));
+
+        // Inspect the first matching tx in detail
+        for (const sig of signatures) {
+          try {
+            let txData: any = null;
+            for (const rpc of SOL_RPCS) {
+              try {
+                const r = await fetch(rpc, {
+                  method: 'POST',
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({
+                    jsonrpc: '2.0', id: 1,
+                    method: 'getTransaction',
+                    params: [sig.signature, { encoding: 'jsonParsed', maxSupportedTransactionVersion: 0 }],
+                  }),
+                  signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+                });
+                const d = await r.json() as any;
+                if (d.result) { txData = d.result; break; }
+              } catch { /* try next */ }
+            }
+            if (!txData) { (result.txDetails ??= []).push({ sig: sig.signature.slice(0, 20), err: 'no txData' }); continue; }
+            const ixs = txData.transaction?.message?.instructions ?? [];
+            const ixInfo = ixs.map((ix: any) => ({
+              program: ix.program ?? ix.programId?.slice(0, 10) ?? '?',
+              type: ix.parsed?.type ?? '?',
+              dest: ix.parsed?.info?.destination?.slice(0, 20) ?? null,
+              lamports: ix.parsed?.info?.lamports ?? null,
+              destMatchesUltron: ix.parsed?.info?.destination === solAddr,
+              amount: ix.parsed?.info?.amount ?? null,
+            }));
+            (result.txDetails ??= []).push({
+              sig: sig.signature.slice(0, 20),
+              ixCount: ixs.length,
+              ixs: ixInfo,
+            });
+          } catch (e) {
+            (result.txDetails ??= []).push({ sig: sig.signature.slice(0, 20), parseErr: String(e) });
+          }
+        }
+        return new Response(JSON.stringify(result, null, 2), { headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // Snorunt Lv.30 — clear the sol-watcher cursor so stuck pending
+    // deposits get re-scanned from fresh. Call ONCE to unblock.
+    if (url.pathname.endsWith('/reset-sol-cursor') && request.method === 'POST') {
+      try {
+        const prev = (this.state as any).last_sol_sig;
+        this.setState({ ...this.state, last_sol_sig: undefined } as any);
+        return new Response(JSON.stringify({ ok: true, previousCursor: prev ?? null }), { headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
     if (url.pathname.endsWith('/rescan-deposits') && request.method === 'POST') {
       try {
         await this._watchSolDeposits();
@@ -3408,11 +3585,28 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
 
     if (signatures.length === 0) return;
 
-    // Check last processed signature to avoid re-processing
+    // Walk back through signatures (newest first) until we hit the
+    // last one we processed. Everything newer than lastProcessed is
+    // "new". If lastProcessed isn't in the returned page at all we
+    // default to processing the top 10 — either the watcher hasn't
+    // run yet or lastProcessed is so old it fell off the page, and
+    // in both cases processing the top 10 is the right call.
+    //
+    // PREVIOUS BUG (Snorunt Lv.30): `.filter(s => s.signature !== lastProcessed)`
+    // only excluded the single sig equal to lastProcessed, not
+    // everything older. And since the end of this method sets
+    // `last_sol_sig = signatures[0]` (the newest), any deposit
+    // processed once with success-OR-partial-failure became
+    // permanently filtered out of subsequent scans, because it was
+    // the one sig the filter was targeting. Fix: walk forward from
+    // the top to the lastProcessed position, take only those sigs.
     const lastProcessed = (this.state as any).last_sol_sig as string | undefined;
-    const newSigs = lastProcessed
-      ? signatures.filter(s => s.signature !== lastProcessed).slice(0, 10)
-      : signatures.slice(0, 5);
+    const lastIdx = lastProcessed
+      ? signatures.findIndex(s => s.signature === lastProcessed)
+      : -1;
+    const newSigs = lastIdx >= 0
+      ? signatures.slice(0, lastIdx)       // everything strictly newer
+      : signatures.slice(0, 10);           // cold-start or fell-off-page
 
     if (newSigs.length === 0) return;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1933,6 +1933,79 @@ app.post('/api/cache/attest-collateral', async (c) => {
   }
 });
 
+// Snorunt Lv.30 — directly attest a SOL-chain collateral delta under
+// a separate 'SOL' asset key. Cross-chain collateral should never
+// collide with the Sui-chain 'SUI' record that attestLiveCollateral
+// owns. Takes { valueUsdCents } so the caller can be precise.
+app.post('/api/cache/attest-sol-collateral', async (c) => {
+  try {
+    const body = await c.req.json() as { valueUsdCents: number };
+    if (!body.valueUsdCents) return c.json({ error: 'valueUsdCents required' }, 400);
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/attest-sol-collateral', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+      body: JSON.stringify(body),
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+// Snorunt Lv.30 — force-dispatch a known Solana deposit sig for
+// deposits whose getSignaturesForAddress returns empty from the
+// worker context (rate-limited RPC, etc.). Manual unblock path.
+app.post('/api/cache/force-dispatch-sol', async (c) => {
+  try {
+    const body = await c.req.json() as { sig: string; lamports: number; suiAddress: string };
+    if (!body.sig || !body.lamports || !body.suiAddress) return c.json({ error: 'sig, lamports, suiAddress required' }, 400);
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/force-dispatch-sol', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+      body: JSON.stringify(body),
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+// Snorunt Lv.30 — debug endpoint to see what _watchSolDeposits sees.
+app.post('/api/cache/debug-sol-watch', async (c) => {
+  try {
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/debug-sol-watch', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+// Snorunt Lv.30 — reset the sol-watcher's last-processed cursor.
+// One-off fix for deposits stuck in pending because the old filter
+// logic excluded a single sig instead of walking forward from it.
+app.post('/api/cache/reset-sol-cursor', async (c) => {
+  try {
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/reset-sol-cursor', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
 // Chansey Lv.40 (#76) — manual activity-yield mint trigger. The
 // treasury mints iUSD up to its current surplus above 110% and sends
 // it to ultron's wallet. No-op if senior <= 1.1 * supply. Also fires

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8239,6 +8239,24 @@ function renderSkiMenu() {
   function parseNsError(raw: string): { display: string; full: string } {
     const lower = raw.toLowerCase();
 
+    // Compute the REAL required amount from the current state. If
+    // there's an active marketplace listing, the user is buying, not
+    // registering, and the required amount is the listing price +
+    // Tradeport's 3% fee. Otherwise fall back to the ~$7.50 SuiNS
+    // registration fee for a 5+ char name.
+    const listing = nsTradeportListing || nsKioskListing;
+    const op = listing ? 'purchase' : 'registration';
+    let requiredUsd = 7.50;
+    if (listing) {
+      try {
+        const suiAmt = Number(BigInt(listing.priceMist)) / 1e9;
+        const fee = listing.source === 'tradeport' ? suiAmt * 0.03 : 0;
+        const totalSui = suiAmt + fee;
+        if (suiPriceCache?.price) requiredUsd = totalSui * suiPriceCache.price;
+      } catch { /* fall through to $7.50 default */ }
+    }
+    const requiredStr = `~$${requiredUsd.toFixed(2)}`;
+
     const isInsufficientBalance =
       lower.includes('insufficientcoinbalance') ||
       lower.includes('insufficient coin balance') ||
@@ -8247,8 +8265,8 @@ function renderSkiMenu() {
     if (isInsufficientBalance) {
       return {
         display:
-          'Insufficient balance — not enough funds to complete the registration.\n\n' +
-          'You need SUI for gas fees plus ~$7.50 worth of one of:\n' +
+          `Insufficient balance — not enough funds to complete the ${op}.\n\n` +
+          `You need SUI for gas fees plus ${requiredStr} worth of one of:\n` +
           '  \u2022 NS (direct payment)\n' +
           '  \u2022 USDC (swapped via DeepBook)\n' +
           '  \u2022 SUI (swapped via DeepBook)\n\n' +
@@ -8262,8 +8280,8 @@ function renderSkiMenu() {
       if (inner.toLowerCase().includes('insufficient')) {
         return {
           display:
-            'Insufficient balance — the wallet could not resolve enough funds for the transaction.\n\n' +
-            'Make sure you have SUI for gas plus enough NS, USDC, or SUI (~$7.50) for the domain.\n\n' +
+            `Insufficient balance — the wallet could not resolve enough funds for the ${op}.\n\n` +
+            `Make sure you have SUI for gas plus enough NS, USDC, or SUI (${requiredStr}) for the domain.\n\n` +
             `Detail: ${inner}`,
           full: raw,
         };


### PR DESCRIPTION
## Summary

Two independent fixes bundled since they share a branch:

1. **Snorunt Lv.30** (#20) — unstick real \$50 SOL deposit from a chain of silent watcher/dispatch bugs. Adds four keeper endpoints for manual recovery + fixes the filter.
2. **Drowzee Lv.20** (#22) — user-facing NS error toast now shows the actual listing price (\$38 for storm.sui on Tradeport) instead of a hardcoded \$7.50.

Both are purely additive — no existing paths removed.

## Snorunt (commit 3b94b94)

Debug trail from a real stuck deposit: user sent 0.58 SOL + 800-tag to ultron's sol address, the pending deposit-intent existed, but nothing happened. Investigation found four cascading issues:

| # | Issue | Fix |
|---|---|---|
| 1 | \`signatures.filter(s => s !== lastProcessed)\` only excluded ONE sig; the next run's \`setState(last_sol_sig = signatures[0])\` permanently filtered out the freshest sig | Walk forward from top to \`lastProcessed\` index, take everything strictly newer |
| 2 | \`_watchSolDeposits\` not in \`_tick\` loop — Helius webhook is the only auto-trigger | **Not fixed here**, noted as follow-up |
| 3 | \`_purgeStaleIntents\` has a 10-min TTL on pending intents. User took longer → intent purged before deposit landed | **Not fixed here** — intent TTL is a policy decision |
| 4 | \`attestCollateral\` hardcodes \`'SUI'\` asset key → SOL deposit fallback OVERWROTE the Sui-chain SUI collateral record | New \`attestSolCollateral\` method writes to \`'SOL'\` key instead |

### New endpoints (all keeper-auth)

| Method | Path | Purpose |
|---|---|---|
| POST | \`/api/cache/reset-sol-cursor\` | Clear last_sol_sig so stuck deposits can be re-scanned |
| POST | \`/api/cache/debug-sol-watch\` | Inspect what the watcher sees (sigs, pending intents, ix parse) without mutating state |
| POST | \`/api/cache/force-dispatch-sol\` | Manually dispatch a known deposit by sig+lamports+suiAddress, bypassing the broken RPC path |
| POST | \`/api/cache/attest-sol-collateral\` | Write a SOL-chain collateral record under the 'SOL' asset key (not 'SUI') |

Used them in sequence to successfully mark brando's stuck intent as matched. The downstream mint/attest leg still needs work (see follow-ups), but the unsticking path now exists and is verified.

### Follow-ups (not in this PR)
- \`_dispatchMatchedIntent\` fallback should route \`sourceChain === 'sol'\` through \`attestSolCollateral\` not \`attestCollateral\`
- Add real Helius webhook route for \`_watchSolDeposits\` so deposits auto-detect
- Decide whether to extend deposit-intent TTL or re-generate on demand
- **Vector integration** (#21) — replace durable nonces with \`blueshift-gg/vector\` per user directive; will likely touch all Solana signing code

## Drowzee (commit bd0fdd2)

User reported: tried to buy \`storm.sui\` on the idle overlay, got toast \"Insufficient balance — not enough funds to complete the registration. You need SUI for gas fees plus ~\$7.50 worth of...\"

Problem: \`storm.sui\` is listed on Tradeport for \$38, not \$7.50. The error message was hardcoded to the registration path (~\$7.50 for a 5+ char name). For a listing purchase, the real required amount is \`listing.priceMist * 1.03\` (3% Tradeport fee) converted through Pyth SUI price.

### Fix
\`parseNsError\` now reads \`nsTradeportListing\` / \`nsKioskListing\` from the enclosing closure, computes the real required USD, and substitutes it. Word \"registration\" swaps to \"purchase\" when a listing is active. Falls back to \$7.50 default for fresh-name registration path.

### Noted, not fixed
The affordability check at \`_updateSendBtnMode\` sums \`tradeSelVal + tradeOutVal\` and treats that as available, but \`buildSwapAndPurchaseTx\` uses only ONE input coin. So the check passes (button enabled) when the actual tx would fail. User's \$30 SUI + \$38 USDC = \$68 passes the check against a \$39 listing, but the builder only routes one side and fails. That's a deeper fix — needs either a multi-input swap builder or stricter affordability check.

## Test plan
- [x] Build clean
- [x] Deployed to dotski (versions fbb280be + 46b6dd3d)
- [x] \`reset-sol-cursor\` returns \`{ok:true, previousCursor:null}\`
- [x] \`debug-sol-watch\` returns pending intent count + sig details (discovered \`sigCount: 0\` from worker context)
- [x] \`force-dispatch-sol\` with brando's stuck deposit successfully marks the intent \`matched\`
- [x] Drowzee fix: error message now reads actual listing price instead of \$7.50

## Out of scope (filed as separate tasks)
- Task #21: Vector SDK integration for Solana signing
- The \`_dispatchMatchedIntent\` cross-chain routing fix
- The affordability check / builder mismatch