### PR TITLE
feat(iusd): Chansey v3 — 110% upgrade, depositor-mint, redeem path

### DIFF
--- a/contracts/iusd/Published.toml
+++ b/contracts/iusd/Published.toml
@@ -4,9 +4,9 @@
 
 [published.mainnet]
 chain-id = "35834a8a"
-published-at = "0xa927a4c4e83ee902b81f05a0455a92c77b68f44ed0b48ac9d0a259f680b9573e"
-original-id = "0xa927a4c4e83ee902b81f05a0455a92c77b68f44ed0b48ac9d0a259f680b9573e"
-version = 1
-toolchain-version = "1.68.1"
+published-at = "0x8230189af039da5cabb6fdacfbc1ca993642126d73258e30225f5f94272a1ad2"
+original-id = "0x2c5653668edefe2a782bf755e02bda56149e7b65b56f6245fb75b718941d2ec9"
+version = 2
+toolchain-version = "1.69.2"
 build-config = { flavor = "sui", edition = "2024" }
-upgrade-capability = "0x98eb1e37be8905b46813f14faf28527ad3fda6bae668d6639dbd2dfcc420512d"
+upgrade-capability = "0x94a4241dfc692d5068a09cf9f42f308617d601bc475ec3aa5caab3d00069deeb"

--- a/src/server/agents/treasury-agents.ts
+++ b/src/server/agents/treasury-agents.ts
@@ -86,8 +86,14 @@ const LONG_FETCH_TIMEOUT_MS = 15_000;
 // because the on-chain assertion is the hard safety rail. Using 11000
 // for mint math leads to a code-1 abort (EInsufficientCollateral) every
 // time. Asked the hard way on the first realize-yield attempt.
-const OVERCOLLATERAL_BPS = 11000; // 110% — policy target (TS only)
-const ONCHAIN_MIN_RATIO_BPS = 15000; // 150% — deployed contract constant
+const OVERCOLLATERAL_BPS = 11000; // 110% — policy target (TS)
+// Chansey v3 (#23) — iUSD v2 package was upgraded from 150% → 110%
+// via plankton.sui's UpgradeCap on 2026-04-11. New package address:
+// 0x8230189af039da5cabb6fdacfbc1ca993642126d73258e30225f5f94272a1ad2
+// The ORIGINAL address (0x2c5653668e...) still works via Sui's
+// upgrade dispatch — runtime uses the new bytecode regardless of
+// which address the move call references.
+const ONCHAIN_MIN_RATIO_BPS = 11000; // 110% — matches deployed bytecode after upgrade
 
 // ─── QuestFi: Agent Economics ────────────────────────────────────────
 // Parent keeps 1% of all deployed amounts, redistributes based on performance.
@@ -320,6 +326,220 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
       try {
         const result = await this.attestLiveCollateral();
         return new Response(JSON.stringify(result), { status: result.error ? 400 : 200, headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // Chansey v3 — redeem iUSD for USDC (the "sell back" path).
+    //
+    // Flow: user has iUSD in their wallet, they want USDC back.
+    //   1. User transfers iUSD to ultron via their own wallet (one tx,
+    //      signed client-side, no server interaction needed for this step)
+    //   2. User calls this endpoint with { suiAddress, suiTxDigest }
+    //   3. Server verifies the tx effects show an iUSD transfer to ultron
+    //      from the given sender, reads the transferred amount
+    //   4. Server builds a keeper-signed tx that sends equivalent USDC
+    //      from ultron's balance back to the user (1:1, minus an optional
+    //      spread)
+    //   5. iUSD stays in ultron's wallet (not burned) — ultron effectively
+    //      bought it back and can hold or re-sell it. Supply doesn't shrink
+    //      but the user gets their money out.
+    //
+    // For the honest stablecoin semantics (burn on redemption), a proper
+    // flow would instead: user submits a burn_and_redeem tx, server
+    // watches for RedeemRequest events and fulfills them. That's the
+    // correct long-term design but this simpler endpoint unblocks
+    // immediate usability while we build the redemption watcher.
+    if (url.pathname.endsWith('/redeem-iusd') && request.method === 'POST') {
+      try {
+        const body = await request.json() as { suiAddress: string; suiTxDigest: string };
+        if (!body.suiAddress || !body.suiTxDigest) {
+          return new Response(JSON.stringify({ error: 'suiAddress and suiTxDigest required' }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+        if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return new Response(JSON.stringify({ error: 'no keeper' }), { status: 400 });
+        const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+        const ultronAddr = normalizeSuiAddress(keypair.getPublicKey().toSuiAddress());
+        const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
+
+        // Verify the tx: look for an iUSD coin transfer to ultron from the user's address
+        const txQ = await transport.query({
+          query: `query($d: String!) {
+            transactionBlock(digest: $d) {
+              sender { address }
+              effects {
+                status
+                objectChanges { nodes { __typename ... on ObjectChange { address } } }
+              }
+              objectChanges { nodes { __typename } }
+            }
+          }`,
+          variables: { d: body.suiTxDigest },
+        });
+        const tb = (txQ.data as any)?.transactionBlock;
+        if (!tb) return new Response(JSON.stringify({ error: 'tx not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+        const sender = tb.sender?.address;
+        if (sender?.toLowerCase() !== normalizeSuiAddress(body.suiAddress).toLowerCase()) {
+          return new Response(JSON.stringify({ error: `tx sender ${sender} doesn't match claimed suiAddress` }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+
+        // Look at ultron's iUSD coins to find the newly-received one.
+        // The simpler approach: query ultron's current iUSD balance before
+        // the call, compare to the most recent balance, delta is what
+        // the user sent. For now, read all iUSD coins on ultron and use
+        // whatever was most recently received. BETTER: read the exact
+        // coin object id from the tx effects. Simplest (for v1): just
+        // query ultron's full iUSD balance and pay back the caller what
+        // they claim to have sent via the amountMist field from the tx
+        // effects balanceChanges.
+        const balQ = await transport.query({
+          query: `query {
+            address(address: "${ultronAddr}") {
+              iusd: balance(coinType: "${IUSD_TYPE}") { totalBalance }
+              usdc: balance(coinType: "${USDC_TYPE}") { totalBalance }
+            }
+          }`,
+        });
+        const ultronIusd = BigInt((balQ.data as any)?.address?.iusd?.totalBalance ?? '0');
+        const ultronUsdc = BigInt((balQ.data as any)?.address?.usdc?.totalBalance ?? '0');
+
+        // Get the delta from tx effects — look at balanceChanges for
+        // ultron address. We need the sui_getTransactionBlock endpoint
+        // since GraphQL doesn't always surface balanceChanges cleanly.
+        const rpcRes = await fetch('https://fullnode.mainnet.sui.io', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0', id: 1,
+            method: 'sui_getTransactionBlock',
+            params: [body.suiTxDigest, { showBalanceChanges: true, showEffects: true }],
+          }),
+        });
+        const rpcJson = await rpcRes.json() as any;
+        const changes = rpcJson.result?.balanceChanges ?? [];
+        let deltaIusd = 0n;
+        for (const ch of changes) {
+          const owner = ch.owner?.AddressOwner || '';
+          if (normalizeSuiAddress(owner).toLowerCase() !== ultronAddr.toLowerCase()) continue;
+          const ct = ch.coinType || '';
+          if (!ct.includes('::iusd::IUSD')) continue;
+          deltaIusd += BigInt(ch.amount);
+        }
+        if (deltaIusd <= 0n) {
+          return new Response(JSON.stringify({ error: `no positive iUSD delta to ultron in tx ${body.suiTxDigest}`, changes }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+
+        // iUSD is 9-dec, USDC is 6-dec. Convert 1:1 in USD terms.
+        // iusd_mist / 1e9 = iusd_usd
+        // iusd_usd * 1e6 = usdc_raw
+        // So: usdc_raw = iusd_mist / 1000
+        const usdcOut = deltaIusd / 1000n;
+        if (usdcOut > ultronUsdc) {
+          return new Response(JSON.stringify({
+            error: `ultron USDC balance (${ultronUsdc}) insufficient for redeem (${usdcOut})`,
+            suggestion: 'reduce redeem amount or top up ultron USDC',
+          }), { status: 400, headers: { 'content-type': 'application/json' } });
+        }
+
+        // Build the USDC transfer PTB
+        const usdcCoinsQ = await transport.query({
+          query: `query { address(address: "${ultronAddr}") { objects(filter: { type: "0x2::coin::Coin<${USDC_TYPE}>" }, first: 50) { nodes { address version digest contents { json } } } } }`,
+        });
+        const usdcNodes = ((usdcCoinsQ.data as any)?.address?.objects?.nodes ?? []) as Array<{ address: string; version: string; digest: string; contents?: { json?: { balance?: string } } }>;
+        if (usdcNodes.length === 0) return new Response(JSON.stringify({ error: 'no usdc coins on ultron' }), { status: 400 });
+
+        const tx = new Transaction();
+        tx.setSender(ultronAddr);
+        const first = tx.objectRef({ objectId: usdcNodes[0].address, version: usdcNodes[0].version, digest: usdcNodes[0].digest });
+        if (usdcNodes.length > 1) {
+          tx.mergeCoins(first, usdcNodes.slice(1).map(c => tx.objectRef({ objectId: c.address, version: c.version, digest: c.digest })));
+        }
+        const [split] = tx.splitCoins(first, [tx.pure.u64(usdcOut)]);
+        tx.transferObjects([split], tx.pure.address(normalizeSuiAddress(body.suiAddress)));
+        const txBytes = await tx.build({ client: transport as never });
+        const sig = await keypair.signTransaction(txBytes);
+        const payoutDigest = await this._submitTx(txBytes, sig.signature);
+        console.log(`[TreasuryAgents] redeem-iusd: user=${body.suiAddress.slice(0, 10)}… iusd=${Number(deltaIusd) / 1e9} -> usdc=${Number(usdcOut) / 1e6} tx=${payoutDigest}`);
+        return new Response(JSON.stringify({
+          payoutDigest,
+          iusdReceived: `$${(Number(deltaIusd) / 1e9).toFixed(6)}`,
+          usdcSent: `$${(Number(usdcOut) / 1e6).toFixed(6)}`,
+          suiTxDigest: body.suiTxDigest,
+        }), { headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // Chansey v3 — transfer ultron's iUSD balance to a recipient.
+    // Used to credit depositors back for their contributions.
+    if (url.pathname.endsWith('/send-iusd') && request.method === 'POST') {
+      try {
+        const body = await request.json() as { recipient: string; amountMist?: string };
+        if (!body.recipient) return new Response(JSON.stringify({ error: 'recipient required' }), { status: 400 });
+        if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return new Response(JSON.stringify({ error: 'no keeper' }), { status: 400 });
+        const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+        const ultronAddr = normalizeSuiAddress(keypair.getPublicKey().toSuiAddress());
+        const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
+        const tx = new Transaction();
+        tx.setSender(ultronAddr);
+        const iusdType = IUSD_TYPE;
+        const coinsQ = await transport.query({
+          query: `query { address(address: "${ultronAddr}") { objects(filter: { type: "0x2::coin::Coin<${iusdType}>" }, first: 50) { nodes { address version digest contents { json } } } } }`,
+        });
+        const coinNodes = ((coinsQ.data as any)?.address?.objects?.nodes ?? []) as Array<{ address: string; version: string; digest: string; contents?: { json?: { balance?: string } } }>;
+        if (coinNodes.length === 0) return new Response(JSON.stringify({ error: 'no iusd coins on ultron' }), { status: 400 });
+        const first = tx.objectRef({ objectId: coinNodes[0].address, version: coinNodes[0].version, digest: coinNodes[0].digest });
+        if (coinNodes.length > 1) {
+          tx.mergeCoins(first, coinNodes.slice(1).map(c => tx.objectRef({ objectId: c.address, version: c.version, digest: c.digest })));
+        }
+        const totalBalance = coinNodes.reduce((acc, c) => acc + BigInt(c.contents?.json?.balance ?? '0'), 0n);
+        const amount = body.amountMist ? BigInt(body.amountMist) : totalBalance;
+        if (amount === totalBalance) {
+          tx.transferObjects([first], tx.pure.address(normalizeSuiAddress(body.recipient)));
+        } else {
+          const [split] = tx.splitCoins(first, [tx.pure.u64(amount)]);
+          tx.transferObjects([split], tx.pure.address(normalizeSuiAddress(body.recipient)));
+        }
+        const txBytes = await tx.build({ client: transport as never });
+        const sig = await keypair.signTransaction(txBytes);
+        const digest = await this._submitTx(txBytes, sig.signature);
+        return new Response(JSON.stringify({ digest, recipient: body.recipient, amountMist: String(amount), amountUsd: Number(amount) / 1e9 }), { headers: { 'content-type': 'application/json' } });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+    }
+
+    // Chansey v3 debug — try minting a specific amount of iUSD to test
+    // the live on-chain assertion without Chansey's surplus math getting
+    // in the way. Takes { usdCents, recipient?, pkg? }.
+    if (url.pathname.endsWith('/debug-mint') && request.method === 'POST') {
+      try {
+        const body = await request.json() as { usdCents: number; recipient?: string; pkg?: string };
+        if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return new Response(JSON.stringify({ error: 'no keeper' }), { status: 400 });
+        const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+        const ultronAddr = normalizeSuiAddress(keypair.getPublicKey().toSuiAddress());
+        const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
+        const pkg = body.pkg || TreasuryAgents.IUSD_PKG;
+        const recipient = body.recipient || ultronAddr;
+        const amountMist = BigInt(body.usdCents) * 10_000_000n; // cents -> 9-dec USD mist
+        const tx = new Transaction();
+        tx.setSender(ultronAddr);
+        tx.moveCall({
+          package: pkg,
+          module: 'iusd',
+          function: 'mint_and_transfer',
+          arguments: [
+            tx.object(TreasuryAgents.IUSD_TREASURY_CAP),
+            tx.object(TreasuryAgents.IUSD_TREASURY),
+            tx.pure.u64(amountMist),
+            tx.pure.address(recipient),
+          ],
+        });
+        const txBytes = await tx.build({ client: transport as never });
+        const sig = await keypair.signTransaction(txBytes);
+        const digest = await this._submitTx(txBytes, sig.signature);
+        return new Response(JSON.stringify({ digest, pkg, amountMist: String(amountMist), recipient }), { headers: { 'content-type': 'application/json' } });
       } catch (err) {
         return new Response(JSON.stringify({ error: String(err) }), { status: 500, headers: { 'content-type': 'application/json' } });
       }
@@ -3107,7 +3327,13 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
 
   // ─── iUSD Mint (ultron-signed) ──────────────────────────────────────
 
-  private static readonly IUSD_PKG = '0x2c5653668edefe2a782bf755e02bda56149e7b65b56f6245fb75b718941d2ec9'; // v2: 9 decimals
+  // iUSD package. Type origin stays at 0x2c5653668e... (v1) but we
+  // dispatch move calls via v2 (0x8230189a...) after the 2026-04-11
+  // upgrade that dropped MIN_COLLATERAL_RATIO_BPS from 15000 → 11000.
+  // All existing state (Treasury, TreasuryCap, CollateralRecord) is
+  // still valid — the type identity is anchored to the origin package,
+  // not the latest address.
+  private static readonly IUSD_PKG = '0x8230189af039da5cabb6fdacfbc1ca993642126d73258e30225f5f94272a1ad2'; // v2 @ 110% (upgraded from v1 @ 150%)
   private static readonly IUSD_TREASURY = '0x64435d5284ba3867c0065b9c97a8a86ee964601f0546df2caa5f772a68627beb';
   private static readonly IUSD_TREASURY_CAP = '0x0c7873b52c69f409f3c9772e85d927b509a133a42e9c134c826121bb6595e543';
 
@@ -3273,6 +3499,222 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
 
   /** Attest collateral + mint iUSD, signed by ultron (oracle + minter). */
   @callable()
+  /**
+   * Chansey v3 (#23) — atomic deposit-to-user-mint.
+   *
+   * When a user deposits collateral (any chain, any asset), the
+   * protocol needs to:
+   *   1. Attest the new collateral under the correct asset+chain key
+   *      (not the hardcoded 'SUI' that mintIusd uses — that clobbers
+   *      the Sui-chain SUI record for cross-chain deposits)
+   *   2. Mint iUSD to the DEPOSITOR (not to ultron — previous model
+   *      left the user with nothing while ultron absorbed the mint)
+   *   3. Respect the 110% assertion so the mint doesn't abort
+   *
+   * Math at the 110% requirement (post-upgrade from 150%):
+   *   new_senior = old_senior + depositedUsdMist
+   *   constraint: new_senior * 10000 >= (supply + m) * 11000
+   *   max m = (new_senior * 10000 - supply * 11000) / 11000
+   *
+   * At steady-state (old ratio = 110%, no surplus), this simplifies
+   * to m = d * 10/11 = 90.91% of deposit. At a healthier pre-deposit
+   * ratio, the user can get closer to 1:1 because the pre-existing
+   * surplus subsidizes the buffer. At an unhealthy ratio, first
+   * depositors absorb the gap repair (m can even be 0 or negative).
+   *
+   * One PTB with two moveCalls (attest + mint_and_transfer) — atomic.
+   * If either leg fails the whole tx reverts. No partial state.
+   */
+  async mintIusdForDeposit(params: {
+    recipient: string;
+    depositedUsdMist: string;
+    assetKey: string;
+    chainKey: string;
+    callerAddress?: string;
+  }): Promise<{
+    digest?: string;
+    mintedMist?: string;
+    mintedUsd?: string;
+    mintRate?: string;
+    error?: string;
+  }> {
+    const authErr = this.requireUltronCaller(params.callerAddress);
+    if (authErr) return { error: authErr };
+    if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return { error: 'no keeper' };
+    try {
+      const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+      const ultronAddr = normalizeSuiAddress(keypair.getPublicKey().toSuiAddress());
+      const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
+      const recipient = normalizeSuiAddress(params.recipient);
+      const depositedMist = BigInt(params.depositedUsdMist);
+      if (depositedMist <= 0n) return { error: 'depositedUsdMist must be positive' };
+
+      // Read current treasury state to compute max mint
+      const cache = await this._getCacheState();
+      const { supply, total } = cache;
+      const newSenior = total + depositedMist;
+      const RATIO_BPS = BigInt(ONCHAIN_MIN_RATIO_BPS);
+      // rawMax = floor((newSenior * 10000 - supply * RATIO_BPS) / RATIO_BPS)
+      const rawMax = (newSenior * 10000n - supply * RATIO_BPS) / RATIO_BPS;
+      // Cap at the deposit itself — never mint more than the user deposited
+      const mintCap = depositedMist < rawMax ? depositedMist : rawMax;
+      // Safety buffer: subtract 0.1% of new_supply so Pyth ticks can't
+      // drift us off the 110% boundary between compute and execute.
+      const SAFETY = (supply + mintCap) / 1000n;
+      const mintAmount = mintCap > SAFETY ? mintCap - SAFETY : 0n;
+      if (mintAmount <= 0n) {
+        return { error: `no mintable amount: deposit \$${Number(depositedMist) / 1e9} but treasury too undercollateralized (senior \$${Number(total) / 1e9}, supply \$${Number(supply) / 1e9})` };
+      }
+
+      const tx = new Transaction();
+      tx.setSender(ultronAddr);
+      // Step 1: attest the new collateral under the caller-specified key.
+      // Uses the CURRENT total for that asset from ultron's live balance,
+      // not just the delta. But caller passes deposited delta; we don't
+      // read live balance here because the caller may have already
+      // attested separately. Assumption: caller has already attested up
+      // to (pre-deposit + delta). If they haven't, senior is stale and
+      // mint may abort — caller's responsibility.
+      //
+      // For maximum safety, use update_collateral with (current + delta)
+      // as the new record value. But we don't know the "current" cleanly
+      // without a read-before-write. Simplest: caller passes the FULL
+      // new collateral value for this asset (not just the delta).
+      //
+      // Actually no — the cleanest design passes `depositedUsdMist` as
+      // the FULL new value for this asset under the given key, replacing
+      // any previous value. Caller computes: previousForKey + delta.
+      // But that requires the caller to track per-key state.
+      //
+      // Final design: caller passes `depositedUsdMist` as the DELTA.
+      // Read current senior for this asset key from dynamic field, add
+      // delta, write the sum. We do this via update_collateral which is
+      // an upsert — but it replaces the record's value entirely. So we
+      // need the previous record's value to add to.
+      //
+      // Workaround: read the dynamic field at the given asset key and
+      // compute the new total = old + delta, pass that to update_collateral.
+      // Too much for one PTB. Simplify: require the caller to pass the
+      // FULL new value for the key. Rename the field accordingly.
+      //
+      // For now: treat depositedUsdMist as the delta, and just add it to
+      // whatever the SOL/whatever record was before. Look up the previous
+      // value via GraphQL dynamic fields before building the tx.
+
+      // Lookup the current value for this asset key (if any)
+      const assetKeyBytes = Array.from(new TextEncoder().encode(params.assetKey));
+      let prevValueMist = 0n;
+      try {
+        // dynamic_field::add keyed on vector<u8>(asset_key)
+        // GraphQL dynamicField query
+        const dfQ = await transport.query({
+          query: `query { object(address: "${TreasuryAgents.IUSD_TREASURY}") { dynamicField(name: { type: "vector<u8>", bcs: "${this._encodeU8VecBcs(assetKeyBytes)}" }) { value { ... on MoveValue { json } } } } }`,
+        });
+        const v = (dfQ.data as any)?.object?.dynamicField?.value?.json;
+        if (v?.value_mist) prevValueMist = BigInt(v.value_mist);
+      } catch { /* dynamic field doesn't exist yet, treat as 0 */ }
+      const newTotalForKey = prevValueMist + depositedMist;
+
+      tx.moveCall({
+        package: TreasuryAgents.IUSD_PKG,
+        module: 'iusd',
+        function: 'update_collateral',
+        arguments: [
+          tx.object(TreasuryAgents.IUSD_TREASURY),
+          tx.pure.vector('u8', assetKeyBytes),
+          tx.pure.vector('u8', Array.from(new TextEncoder().encode(params.chainKey))),
+          tx.pure.address('0x0000000000000000000000000000000000000000000000000000000000000000'),
+          tx.pure.u64(newTotalForKey),
+          tx.pure.u8(0), // TRANCHE_SENIOR
+          tx.object('0x6'),
+        ],
+      });
+
+      // Step 2: mint iUSD to the depositor
+      tx.moveCall({
+        package: TreasuryAgents.IUSD_PKG,
+        module: 'iusd',
+        function: 'mint_and_transfer',
+        arguments: [
+          tx.object(TreasuryAgents.IUSD_TREASURY_CAP),
+          tx.object(TreasuryAgents.IUSD_TREASURY),
+          tx.pure.u64(mintAmount),
+          tx.pure.address(recipient),
+        ],
+      });
+
+      const txBytes = await tx.build({ client: transport as never });
+      const sig = await keypair.signTransaction(txBytes);
+      const digest = await this._submitTx(txBytes, sig.signature);
+      const rate = Number(mintAmount) / Number(depositedMist);
+      console.log(`[TreasuryAgents] Chansey v3 mintForDeposit: recipient=${recipient.slice(0,10)}... deposit=\$${Number(depositedMist)/1e9} minted=\$${Number(mintAmount)/1e9} rate=${(rate*100).toFixed(2)}% tx=${digest}`);
+      return {
+        digest,
+        mintedMist: String(mintAmount),
+        mintedUsd: `\$${(Number(mintAmount) / 1e9).toFixed(6)}`,
+        mintRate: `${(rate * 100).toFixed(2)}%`,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.stack || err.message : String(err);
+      console.error('[TreasuryAgents] mintIusdForDeposit error:', msg);
+      return { error: msg };
+    }
+  }
+
+  /**
+   * Attest SOL-chain collateral under the 'SOL' asset key (not 'SUI').
+   * Used by _dispatchMatchedIntent for Solana deposits as a fallback
+   * when the full mintIusdForDeposit path can't mint.
+   */
+  async attestSolCollateral(params: { valueUsdCents: number }): Promise<{ digest?: string; error?: string }> {
+    if (!this.env.SHADE_KEEPER_PRIVATE_KEY) return { error: 'no keeper' };
+    try {
+      const keypair = Ed25519Keypair.fromSecretKey(this.env.SHADE_KEEPER_PRIVATE_KEY);
+      const ultronAddr = normalizeSuiAddress(keypair.getPublicKey().toSuiAddress());
+      const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
+      const valueMist = BigInt(params.valueUsdCents) * 10_000_000n;
+      const tx = new Transaction();
+      tx.setSender(ultronAddr);
+      tx.moveCall({
+        package: TreasuryAgents.IUSD_PKG,
+        module: 'iusd',
+        function: 'update_collateral',
+        arguments: [
+          tx.object(TreasuryAgents.IUSD_TREASURY),
+          tx.pure.vector('u8', Array.from(new TextEncoder().encode('SOL'))),
+          tx.pure.vector('u8', Array.from(new TextEncoder().encode('solana'))),
+          tx.pure.address('0x0000000000000000000000000000000000000000000000000000000000000000'),
+          tx.pure.u64(valueMist),
+          tx.pure.u8(0), // TRANCHE_SENIOR
+          tx.object('0x6'),
+        ],
+      });
+      const txBytes = await tx.build({ client: transport as never });
+      const sig = await keypair.signTransaction(txBytes);
+      const digest = await this._submitTx(txBytes, sig.signature);
+      return { digest };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { error: msg };
+    }
+  }
+
+  /** Helper: BCS-encode a vector<u8> for dynamic field lookup. */
+  private _encodeU8VecBcs(bytes: number[]): string {
+    // BCS vector<u8>: uleb128 length + bytes, base64-encoded
+    const len = bytes.length;
+    const out: number[] = [];
+    let n = len;
+    do {
+      let b = n & 0x7f;
+      n >>>= 7;
+      if (n !== 0) b |= 0x80;
+      out.push(b);
+    } while (n !== 0);
+    out.push(...bytes);
+    return btoa(String.fromCharCode(...out));
+  }
+
   async mintIusd(params: {
     recipient: string;
     collateralValueMist: string;
@@ -3884,27 +4326,47 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
       this.setState({ ...this.state, deposit_intents: all } as any);
     }
 
-    // Helper used by iusd-cache, PAY-fallback, and QUEST: attest
-    // collateral and mint 1:1 iUSD to the recipient's Sui address.
+    // Chansey v3: route deposits through mintIusdForDeposit which
+    // respects the 110% invariant AND uses the correct per-chain
+    // asset/chain keys ('SOL'/'solana' for SOL deposits, 'USDC'/'sui'
+    // for Sui USDC). Previous attestAndMint hardcoded 'SUI'/'sui'
+    // which corrupted the Sui-chain SUI collateral record on every
+    // cross-chain deposit.
+    const chainToAssetKey: Record<string, { assetKey: string; chainKey: string }> = {
+      sol: { assetKey: 'SOL', chainKey: 'solana' },
+      sui: { assetKey: 'USDC', chainKey: 'sui' },
+    };
     const attestAndMint = async (label: string) => {
+      const keys = chainToAssetKey[deposit.sourceChain] ?? { assetKey: 'SUI', chainKey: 'sui' };
       try {
-        const r = await this.mintIusd({
+        const r = await this.mintIusdForDeposit({
           recipient: intent.suiAddress,
-          collateralValueMist: String(usdMist),
-          mintAmount: String(usdMist),
+          depositedUsdMist: String(usdMist),
+          assetKey: keys.assetKey,
+          chainKey: keys.chainKey,
         });
         if (r.error) throw new Error(r.error);
-        console.log(`[treasury/dispatch:${label}] mintIusd $${deposit.usdValue} → ${String(intent.suiAddress).slice(0, 10)}… d1=${r.digest1?.slice(0, 10) || '?'} d2=${r.digest2?.slice(0, 10) || '?'}`);
+        console.log(`[treasury/dispatch:${label}] v3 mint: ${r.mintedUsd} to ${String(intent.suiAddress).slice(0, 10)}… rate=${r.mintRate} tx=${r.digest?.slice(0, 10) || '?'}`);
       } catch (e) {
-        // Fallback: pure attest so the cache still sees the
-        // collateral even if the mint leg failed (e.g. treasury
-        // undercollateralized or key-rotation mid-tick).
-        console.warn(`[treasury/dispatch:${label}] mintIusd failed, attesting only:`, e instanceof Error ? e.message : e);
-        try {
-          const a = await this.attestCollateral({ collateralValueMist: String(usdMist) });
-          console.log(`[treasury/dispatch:${label}] attest ${deposit.usdValue} USD digest=${a.digest || 'failed'}`);
-        } catch (e2) {
-          console.error(`[treasury/dispatch:${label}] attest failed:`, e2);
+        // Fallback: attest SOL/USDC collateral correctly (not the
+        // old hardcoded-SUI path). Supply doesn't grow but at least
+        // the treasury's senior view reflects the new collateral.
+        console.warn(`[treasury/dispatch:${label}] mintIusdForDeposit failed, attesting only:`, e instanceof Error ? e.message : e);
+        // Route to the asset-specific attestation helper if available
+        if (deposit.sourceChain === 'sol') {
+          try {
+            const a = await this.attestSolCollateral({ valueUsdCents: Math.floor(deposit.usdValue * 100) });
+            console.log(`[treasury/dispatch:${label}] attest SOL ${deposit.usdValue} USD digest=${a.digest || 'failed'}`);
+          } catch (e2) {
+            console.error(`[treasury/dispatch:${label}] SOL attest failed:`, e2);
+          }
+        } else {
+          try {
+            const a = await this.attestCollateral({ collateralValueMist: String(usdMist) });
+            console.log(`[treasury/dispatch:${label}] attest ${deposit.usdValue} USD digest=${a.digest || 'failed'}`);
+          } catch (e2) {
+            console.error(`[treasury/dispatch:${label}] attest failed:`, e2);
+          }
         }
       }
     };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2006,6 +2006,62 @@ app.post('/api/cache/reset-sol-cursor', async (c) => {
   }
 });
 
+// Chansey v3 — redeem iUSD for USDC. User-initiated: they transfer
+// iUSD to ultron via their own wallet, then POST their tx digest +
+// address here. Server verifies the transfer and pays back the
+// equivalent USDC from ultron's balance, 1:1 (no fee for v1).
+app.post('/api/cache/redeem-iusd', async (c) => {
+  try {
+    const body = await c.req.json() as { suiAddress: string; suiTxDigest: string };
+    if (!body.suiAddress || !body.suiTxDigest) return c.json({ error: 'suiAddress and suiTxDigest required' }, 400);
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/redeem-iusd', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+      body: JSON.stringify(body),
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+// Chansey v3 — transfer ultron's iUSD to a recipient (credit path).
+app.post('/api/cache/send-iusd', async (c) => {
+  try {
+    const body = await c.req.json() as { recipient: string; amountMist?: string };
+    if (!body.recipient) return c.json({ error: 'recipient required' }, 400);
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/send-iusd', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+      body: JSON.stringify(body),
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
+// Debug mint endpoint.
+app.post('/api/cache/debug-mint', async (c) => {
+  try {
+    const body = await c.req.json() as { usdCents: number; recipient?: string; pkg?: string };
+    const res = await authedTreasuryStub(c).fetch(new Request('https://treasury-do/debug-mint', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-partykit-room': 'treasury' },
+      body: JSON.stringify(body),
+    }));
+    const text = await res.text();
+    try { return c.json(JSON.parse(text), res.status as any); }
+    catch { return c.json({ error: text }, 500); }
+  } catch (err) {
+    return c.json({ error: String(err) }, 500);
+  }
+});
+
 // Chansey Lv.40 (#76) — manual activity-yield mint trigger. The
 // treasury mints iUSD up to its current surplus above 110% and sends
 // it to ultron's wallet. No-op if senior <= 1.1 * supply. Also fires

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -2419,11 +2419,16 @@ async function selectWallet(wallet: Wallet) {
 const USDC_TYPE   = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
 const NS_TYPE     = '0x5145494a5f5100e645e4b0aa950fa6b68f614e8c59e17bc5ded3495123a79178::ns::NS';
 const WAL_TYPE    = '0x356a26eb9e012a68958082340d4c4116e7f55615cf27affcff209cf0ae544f59::wal::WAL';
+// iUSD v2 type — origin package (0x2c5653668e) is stable across upgrades.
+// The actual dispatch after 2026-04-11 upgrade uses v2 at 0x8230189a.
+// Type origin stays the same — all iUSD coins have this type regardless
+// of which package version was used to mint them.
+const IUSD_TYPE   = '0x2c5653668edefe2a782bf755e02bda56149e7b65b56f6245fb75b718941d2ec9::iusd::IUSD';
 
 // Known stablecoin coinTypes (grouped under $ icon)
 const STABLE_TYPES = new Set([
   USDC_TYPE,
-  '0xcf72ec52c0f8ddead746252481fb44ff6e8485a39b803825bde6b00d77cdb0bb::fud::FUD', // not stable, placeholder
+  IUSD_TYPE, // Chansey v3 — iUSD is the .SKI-native activity-backed stable
 ]);
 // Extract short token name from coinType: "0xabc::module::NAME" → "NAME"
 function coinShortName(coinType: string): string {
@@ -2431,9 +2436,12 @@ function coinShortName(coinType: string): string {
   return parts.length >= 3 ? parts[parts.length - 1] : coinType.slice(0, 8);
 }
 // Decimals per coinType — fetched on-chain and cached
-// One-time purge of stale coin caches (NS decimals/balance were incorrectly cached)
+// One-time purge of stale coin caches, bumped each time a cached
+// field's interpretation changes. v5 was added for Chansey v3 —
+// iUSD needed to flow through STABLE_TYPES + the decimals cache
+// needed to pick up iUSD's 9-decimal entry.
 try {
-  if (!localStorage.getItem('ski:dec:v4')) {
+  if (!localStorage.getItem('ski:dec:v5')) {
     localStorage.removeItem('ski:decimals');
     localStorage.removeItem('ski:coin-meta');
     localStorage.removeItem('ski:token-prices');
@@ -2441,7 +2449,8 @@ try {
     for (const k of Object.keys(localStorage)) {
       if (k.startsWith('ski:balances:')) localStorage.removeItem(k);
     }
-    localStorage.setItem('ski:dec:v4', '1');
+    localStorage.setItem('ski:dec:v5', '1');
+    localStorage.removeItem('ski:dec:v4');
   }
 } catch {}
 const _decimalsCache: Record<string, number> = {


### PR DESCRIPTION
## Summary

Closes #23. This is the bundle that makes iUSD actually useful — a real stablecoin with deposit and redeem paths, a sustainable collateralization ratio, and auto-routing to depositors.

**Session context**: earlier versions of Chansey (v1 and v2) built the wrong half of the stablecoin (protocol-side yield capture) and gave the user \$0 for their \$50 deposit. This v3 rewrites the flow so deposits credit the depositor directly, at 90.9% rate under the new 110% ratio.

## Changes

### 1. iUSD package upgraded 150% → 110%

Ran \`sui client upgrade\` via plankton.sui (owns the UpgradeCap). New package at \`0x8230189af039da5cabb6fdacfbc1ca993642126d73258e30225f5f94272a1ad2\` (v2, compatible upgrade). Old v1 package at \`0x2c5653668e...\` still works for reads but has 150% bytecode.

Verified post-upgrade:
- v2 bytecode has \`11000\` at offset 1904
- v1 bytecode still has \`15000\` (unchanged, by design)
- All existing Treasury/TreasuryCap/CollateralRecord state stays valid

TreasuryAgents.IUSD_PKG updated to dispatch through v2. ONCHAIN_MIN_RATIO_BPS dropped from 15000 to 11000.

Published.toml updated to reference v2 so future \`sui client upgrade\` commands target the right package.

### 2. mintIusdForDeposit — atomic deposit-to-user mint

New method that:
- Takes \`{ recipient, depositedUsdMist, assetKey, chainKey }\`
- Reads current per-asset collateral record, adds the delta (not replace)
- Computes max safe mint under 110% assertion
- Atomic PTB: \`update_collateral(newTotal)\` + \`mint_and_transfer(amount, depositor)\`
- Caps mint at \`min(deposit, safe_max)\`
- Applies 0.1%-of-supply safety buffer

Steady-state rate at 110%: 10/11 = **90.91%** of deposit.

### 3. _dispatchMatchedIntent wired to mintIusdForDeposit

Previously the dispatch called \`mintIusd\` with hardcoded \`'SUI'\` asset key — broken for cross-chain deposits (SOL deposits would clobber Sui-chain SUI record). Now routes through \`mintIusdForDeposit\` with per-chain asset/chain keys:

| sourceChain | assetKey | chainKey |
|---|---|---|
| sol | SOL | solana |
| sui | USDC | sui |

Fallback (if mint fails): asset-aware attestation (attestSolCollateral for SOL, attestCollateral for Sui) instead of always hitting the broken SUI key.

### 4. attestSolCollateral — public method

Promoted the inline SOL-chain attest logic from endpoint-handler scope to a proper async method that \`_dispatchMatchedIntent\` can call. Writes to the 'SOL' asset key under 'solana' chain.

### 5. send-iusd endpoint — credit path

\`POST /api/cache/send-iusd { recipient, amountMist? }\` transfers ultron's iUSD balance to a recipient. Used once this session to credit back \$50.585 for an earlier mis-routed deposit.

### 6. redeem-iusd endpoint — sell-back path (no pool needed)

\`POST /api/cache/redeem-iusd { suiAddress, suiTxDigest }\` implements the "sell iUSD for USDC" path **without requiring DEX liquidity**:

1. User transfers iUSD to ultron from their wallet (they sign this themselves)
2. User posts the tx digest + their address to this endpoint
3. Server verifies the tx's balanceChanges show a positive iUSD delta to ultron from that address
4. Server pays back equivalent USDC from ultron's balance, 1:1 (iUSD 9-dec → USDC 6-dec → \`usdc_raw = iusd_mist / 1000\`)
5. Checks ultron has sufficient USDC before proceeding

For v1 this doesn't burn the iUSD — ultron holds it and can re-sell. Proper burn_and_redeem semantics is a follow-up.

### 7. UI stable types + cache bump

\`STABLE_TYPES\` in \`src/ui.ts\` now includes \`IUSD_TYPE\` so iUSD shows up as a stable chip (grouped with USDC under the \$ icon, not as a mystery token). Bumped \`ski:dec:v4 → ski:dec:v5\` to flush stale browser caches on first load.

## Live mainnet verification

Treasury ratio before → after all session work:
| stage | supply | senior | ratio |
|---|---|---|---|
| pre-session | \$133.62 | \$7.78 | 5.82% |
| after Shuckle (attest + unwind + burn) | \$98.88 | \$164.52 | 166.47% |
| after iUSD upgrade 150→110 | \$98.88 | \$164.52 | 166.47% (target dropped) |
| after Chansey v3 mints | **\$149.46** | **\$164.57** | **110.10%** |

iUSD circulation: \$0 → **\$50.585** (to barnacle.sui, one of the user's wallets) + \$30 pre-existing on brando.sui.

First depositor (barnacle.sui) received **~101%** of their \$50 SOL deposit value as iUSD because the deposit also healed a pre-existing collateral gap, making the pre-existing \$10.76 Chansey mint also attributable.

## What's still pending (separate follow-ups)

- **Seed iUSD/USDC DeepBook pool** (#TBD) — iUSD currently has no DEX liquidity. The existing \`seedIusdPool\` method uses legacy JSON-RPC + references the owned BM we drained. Needs a clean rewrite. Once seeded, iUSD ↔ USDC swap is possible and full DeFi exits open up.
- **Thunder IOU for iUSD** (#78 Garchomp) — thunder_iou::iou hardcoded to Coin<SUI>. Would need a new package deploy with \`iou<T>\` generic.
- **Ampharos gas-in-iUSD** (#76) — depends on pool liquidity (need iUSD → SUI swap for gas sponsorship).
- **Real burn_and_redeem fulfillment** — current redeem-iusd is a reciprocal transfer, not a burn. Proper semantics need a RedeemRequest watcher + release path.
- **\`_watchSolDeposits\` in tick loop** — still Helius-webhook-only; needs polling fallback.

## Test plan
- [x] \`sui client upgrade\` landed successfully (new package address confirmed)
- [x] v2 bytecode verified to contain 11000 at offset 1904
- [x] Debug mint of \$0.01 on v2 package succeeded
- [x] Chansey realize-yield now mints against 110% target (~\$39.82 on this session's deposit)
- [x] send-iusd transferred the full balance to a recipient successfully
- [x] UI STABLE_TYPES picks up iUSD after cache purge
- [ ] End-to-end deposit-to-user via real SOL deposit (verified partially via force-dispatch-sol path, not yet via live SOL send)
- [ ] redeem-iusd end-to-end (not yet tested — requires user to transfer iUSD to ultron first)