### PR TITLE
Regizapdos — Thunder attachment hardening (Zapdos × Registeel fusion)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,6 +54,6 @@
 
   <div id="ski-modal"></div>
 
-  <script type="module" src="./dist/ski.js?v=38"></script>
+  <script type="module" src="./dist/ski.js?v=74"></script>
 </body>
 </html>

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -12521,8 +12521,14 @@ function bindEvents() {
       // reading from the File object.
       type _PendingFile = { fileName: string; mimeType: string; data: Uint8Array; previewUrl?: string };
       const _pendingThunderFiles: _PendingFile[] = [];
-      const _MAX_ATTACH_BYTES = 10 * 1024 * 1024; // 10 MB per file (SDK default)
-      const _MAX_ATTACH_COUNT = 10;
+      // Zapdos Lv.40 — align UI limits with the SDK's actual enforcement.
+      // ATTACH_MAX_FILE_BYTES = 2 MB, ATTACH_MAX_FILES = 4, ATTACH_MAX_TOTAL_BYTES = 5 MB
+      // in `src/client/thunder-stack.ts`. Reject large files at the UI
+      // so the user sees the error before a 10 MB upload fails silently
+      // in the SDK layer.
+      const _MAX_ATTACH_BYTES = 2 * 1024 * 1024;
+      const _MAX_ATTACH_COUNT = 4;
+      const _MAX_ATTACH_TOTAL_BYTES = 5 * 1024 * 1024;
       const _attachChips = _idleOverlay.querySelector('#ski-idle-thunder-attach-chips') as HTMLElement | null;
       const _attachBtn = _idleOverlay.querySelector('#ski-idle-thunder-attach') as HTMLButtonElement | null;
       const _attachFileInput = _idleOverlay.querySelector('#ski-idle-thunder-file-input') as HTMLInputElement | null;
@@ -12642,7 +12648,12 @@ function bindEvents() {
           return;
         }
         if (file.size > _MAX_ATTACH_BYTES) {
-          showToast(`${file.name} > 10 MB — too big`);
+          showToast(`${file.name} > 2 MB — too big`);
+          return;
+        }
+        const runningTotal = _pendingThunderFiles.reduce((n, p) => n + p.data.byteLength, 0);
+        if (runningTotal + file.size > _MAX_ATTACH_TOTAL_BYTES) {
+          showToast(`Attachments total > 5 MB — drop one first`);
           return;
         }
         const buf = await file.arrayBuffer();
@@ -13538,7 +13549,24 @@ function bindEvents() {
       // persisted in IndexedDB — raw key material never leaves the
       // browser's crypto store, so a localStorage dump yields ciphertext
       // alone with no way to recover plaintext.
-      type _ThunderEntry = { text: string; senderAddress: string; createdAt: number; messageId: string };
+      // Zapdos Lv.30 Drill Peck — attachment metadata survives cache
+      // round-trip so reopened storms render chips/thumbs immediately.
+      // We persist refs only (storageId, fileName, mimeType, fileSize);
+      // decrypted bytes are re-fetched via the SDK's Seal handle on
+      // click. Bytes live in Walrus, not localStorage.
+      type _ThunderAttachmentRef = {
+        fileName?: string;
+        mimeType?: string;
+        fileSize?: number;
+        wire?: { storageId?: string };
+      };
+      type _ThunderEntry = {
+        text: string;
+        senderAddress: string;
+        createdAt: number;
+        messageId: string;
+        attachments?: _ThunderAttachmentRef[];
+      };
       const _THUNDER_HIST_KEY = (gid: string) => `ski:thunder-hist:v2:${gid}`;
       const _THUNDER_HIST_TTL = 24 * 60 * 60 * 1000;
       const _IDB_NAME = 'ski-crypto';
@@ -13843,7 +13871,7 @@ function bindEvents() {
         // visible — _renderThunderComposePreview reads the open state.
         _renderThunderComposePreview?.();
 
-        let entries: Array<{ text: string; senderAddress: string; createdAt: number; messageId: string }> = [];
+        let entries: _ThunderEntry[] = [];
         try {
           // Fetch via getThunders so Seal decryption + padding-strip runs.
           // The raw DO payload is Seal ciphertext — decoding it as text shows
@@ -13856,6 +13884,17 @@ function bindEvents() {
             senderAddress: m.senderAddress || '',
             createdAt: m.createdAt ?? Date.now(),
             messageId: m.messageId || `msg-${m.order}`,
+            // Zapdos Lv.30 — preserve attachment metadata only (refs, no bytes).
+            // Bytes live in Walrus + get re-fetched via SDK handle on click.
+            // The ref shape matches what the bubble renderer reads at 14780.
+            attachments: Array.isArray(m.attachments) && m.attachments.length > 0
+              ? m.attachments.map((a: any) => ({
+                  fileName: a.fileName,
+                  mimeType: a.mimeType,
+                  fileSize: a.fileSize,
+                  wire: a.wire ? { storageId: a.wire.storageId } : undefined,
+                }))
+              : undefined,
           }));
         } catch { /* fallback to empty */ }
         // Always clear the loading class on the send button once the fetch


### PR DESCRIPTION
## Regizapdos — Electric × Steel fusion

Zapdos hardens Thunder attachments; Registeel's ironclad shell locks them in cache. Fusion form: **ironclad thunderbolt messenger** — closes issue #146 (Zapdos) and builds on the Registeel SDK foundation (ULTRON_SOL_ADDRESS + Helius proxy, see memory: Registeel Iron Defense).

## Moves landed
- **Zapdos Lv.30 — Drill Peck** — `_ThunderEntry` carries optional attachments (storageId, fileName, mimeType, fileSize) so reopened storms paint attachment chips/thumbs immediately instead of flashing text-only until the fresh DO fetch completes. Bytes stay in Walrus; only refs cross the localStorage boundary. AES-GCM key (thunder-hist-aes in IDB) stays non-extractable.
- **Zapdos Lv.40 — Discharge** — align UI attachment limits with the SDK's actual enforcement in `src/client/thunder-stack.ts`:
  - `ATTACH_MAX_FILE_BYTES` 10 MB → **2 MB** (matches SDK)
  - `ATTACH_MAX_FILES` 10 → **4** (matches SDK)
  - `ATTACH_MAX_TOTAL_BYTES` — new pre-upload check at **5 MB total** (matches SDK)
  Users now see the reject toast before a 10 MB upload hits the SDK layer and silently fails.
- **Cache bust** v=73 → v=74.

## Registeel side (prior art, no new Registeel commits here)
- `ULTRON_SOL_ADDRESS` const + Helius proxy landed in `f7986b5` on nursery
- The iron shell metaphor: the encrypted localStorage cache shield, the non-extractable IDB key, and the pre-upload size guard together form Regizapdos's defense layer

## Scout report (Lv.10 audit from parallel subagent)
- **Main send paths all wire `files` correctly** ✓ — line 13692 (iUSD transfer), line 13739 (SUI shielded transfer), line 13778 (main text send)
- **Ancillary paths drop files by design** ✓ — read receipts (3908), quick-reply (7982) — acceptable, not user-facing
- **Walrus failure handling** ✓ — whole send fails cleanly, no silent text orphaning
- **WaaP attachment path** ⚠ — untested, no BCS re-serialization guard; deferred to future Lv.50 Thunder move
- **Upload progress UI** deferred

## Deferred
- Lv.50 Thunder — WaaP attachment path verification + fallback (needs live repro)
- Upload progress indicator (large-file UX polish)

## Test plan
- [ ] Send a 1.5 MB image → renders inline on send and on reopen after page refresh
- [ ] Attempt to attach a 3 MB file → UI toast rejects with "> 2 MB — too big"
- [ ] Attach 4 files totaling 4.5 MB → accepts; adding a 5th triggers "Max 4 attachments"
- [ ] Attach 4 × 1.5 MB files (6 MB total) → 4th add triggers "> 5 MB — drop one first"
- [ ] Reopen a storm with cached messages containing attachments → chips render immediately, click decrypts via SDK handle

Closes #146.