### PR TITLE
Mega Sableye — private interaction set

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,6 +54,6 @@
 
   <div id="ski-modal"></div>
 
-  <script type="module" src="./dist/ski.js?v=74"></script>
+  <script type="module" src="./dist/ski.js?v=75"></script>
 </body>
 </html>

--- a/src/client/sableye.ts
+++ b/src/client/sableye.ts
@@ -1,0 +1,251 @@
+/**
+ * Sableye — private interaction set.
+ *
+ * Tracks SuiNS counterparties brando has touched privately (Thunder
+ * messaging, Sui transfers, cross-chain credits). The set is stored
+ * as ciphertext in the Chronicom Durable Object so the operator can
+ * never see plaintext membership. The AES-GCM key is non-extractable
+ * and lives in the browser's IndexedDB keystore — raw key material
+ * never leaves the device.
+ *
+ * Shape of the decrypted payload:
+ *   { names: string[]; byChain: Record<'sui'|'btc'|'sol'|'eth'|'tron', string[]>; lastTouch: Record<string, number> }
+ *
+ * Public API:
+ *   warmSableye()        — fetch + decrypt on wallet connect, populates cache
+ *   hasSableye(name)     — synchronous lookup (for roster render)
+ *   noteCounterparty()   — record an interaction, debounced persist
+ *   resetSableye()       — clear on disconnect
+ *
+ * See issue #145.
+ */
+
+const _IDB_NAME = 'ski-crypto';
+const _IDB_STORE = 'keys';
+const _IDB_KEY_ID = 'sableye-aes';
+const _PERSIST_DEBOUNCE_MS = 2000;
+const _MAX_NAMES = 512;
+
+// Chronicom is keyed per-wallet by Sui address. warmSableye() stashes
+// the owner so subsequent persists can target the right DO instance
+// without importing ui.ts state.
+let _ownerAddr = '';
+const _chronicomUrl = () => `/api/chronicom/sableye?addr=${encodeURIComponent(_ownerAddr)}`;
+
+type Chain = 'sui' | 'btc' | 'sol' | 'eth' | 'tron';
+
+interface SableyePayload {
+  names: string[];
+  byChain: Partial<Record<Chain, string[]>>;
+  lastTouch: Record<string, number>;
+}
+
+let _set: Set<string> = new Set();
+let _payload: SableyePayload = { names: [], byChain: {}, lastTouch: {} };
+let _keyPromise: Promise<CryptoKey | null> | null = null;
+let _persistTimer: ReturnType<typeof setTimeout> | null = null;
+let _dirty = false;
+
+// ─── IndexedDB AES-GCM key ────────────────────────────────────────────
+const _openDb = (): Promise<IDBDatabase> => new Promise((resolve, reject) => {
+  const req = indexedDB.open(_IDB_NAME, 1);
+  req.onupgradeneeded = () => { req.result.createObjectStore(_IDB_STORE); };
+  req.onsuccess = () => resolve(req.result);
+  req.onerror = () => reject(req.error);
+});
+const _idbGet = (db: IDBDatabase, k: string) => new Promise<unknown>((resolve, reject) => {
+  const tx = db.transaction(_IDB_STORE, 'readonly');
+  const req = tx.objectStore(_IDB_STORE).get(k);
+  req.onsuccess = () => resolve(req.result);
+  req.onerror = () => reject(req.error);
+});
+const _idbPut = (db: IDBDatabase, k: string, v: unknown) => new Promise<void>((resolve, reject) => {
+  const tx = db.transaction(_IDB_STORE, 'readwrite');
+  tx.objectStore(_IDB_STORE).put(v, k);
+  tx.oncomplete = () => resolve();
+  tx.onerror = () => reject(tx.error);
+});
+const _getKey = (): Promise<CryptoKey | null> => {
+  if (_keyPromise) return _keyPromise;
+  _keyPromise = (async () => {
+    try {
+      const db = await _openDb();
+      let key = await _idbGet(db, _IDB_KEY_ID) as CryptoKey | undefined;
+      if (!key) {
+        key = await crypto.subtle.generateKey(
+          { name: 'AES-GCM', length: 256 },
+          false, // non-extractable
+          ['encrypt', 'decrypt'],
+        );
+        await _idbPut(db, _IDB_KEY_ID, key);
+      }
+      return key;
+    } catch { return null; }
+  })();
+  _keyPromise.catch(() => { _keyPromise = null; });
+  return _keyPromise;
+};
+
+const _bytesToB64 = (u8: Uint8Array): string => btoa(String.fromCharCode(...u8));
+const _b64ToBytes = (b64: string): Uint8Array => Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+
+// ─── Envelope encrypt/decrypt ─────────────────────────────────────────
+async function _encrypt(payload: SableyePayload): Promise<string | null> {
+  const key = await _getKey();
+  if (!key) return null;
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const pt = new TextEncoder().encode(JSON.stringify(payload));
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, pt));
+  return JSON.stringify({ v: 1, iv: _bytesToB64(iv), ct: _bytesToB64(ct) });
+}
+
+async function _decrypt(envelope: string): Promise<SableyePayload | null> {
+  try {
+    const env = JSON.parse(envelope) as { v?: number; iv?: string; ct?: string };
+    if (!env?.iv || !env?.ct) return null;
+    const key = await _getKey();
+    if (!key) return null;
+    const iv = _b64ToBytes(env.iv);
+    const ct = _b64ToBytes(env.ct);
+    const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ct);
+    const obj = JSON.parse(new TextDecoder().decode(pt)) as SableyePayload;
+    if (!obj || !Array.isArray(obj.names)) return null;
+    return { names: obj.names, byChain: obj.byChain || {}, lastTouch: obj.lastTouch || {} };
+  } catch { return null; }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Load the encrypted set from Chronicom + decrypt into local cache.
+ * Call on wallet connect. Safe to call multiple times — idempotent.
+ */
+export async function warmSableye(ownerAddr: string): Promise<void> {
+  if (!ownerAddr) return;
+  _ownerAddr = ownerAddr;
+  try {
+    const r = await fetch(_chronicomUrl());
+    if (!r.ok) return;
+    const j = await r.json() as { cipher?: string; updatedAt?: number; xchainLog?: Array<{ fromAddress: string; chain: string; ts: number }> };
+    if (j.cipher) {
+      const dec = await _decrypt(j.cipher);
+      if (dec) {
+        _payload = dec;
+        _set = new Set(dec.names);
+      }
+    }
+    // Merge any cross-chain webhook touches the server has logged since
+    // last sync. The server only knows fromAddresses; we rely on the
+    // browser's own reverseLookupName (in ui/thunder stack) to map back
+    // to SuiNS names later — for now we just stash the raw log so the
+    // ui layer can process it on demand.
+    if (Array.isArray(j.xchainLog) && j.xchainLog.length > 0) {
+      _pendingXchainLog = j.xchainLog;
+    }
+  } catch { /* non-blocking */ }
+}
+
+let _pendingXchainLog: Array<{ fromAddress: string; chain: string; ts: number }> = [];
+
+/**
+ * Drain the pending xchain webhook log. The caller (ui.ts) is expected
+ * to resolve each fromAddress to a bare name via its reverse-lookup
+ * cache and feed results back via `noteCounterparty`.
+ */
+export function drainXchainLog(): Array<{ fromAddress: string; chain: string; ts: number }> {
+  const out = _pendingXchainLog;
+  _pendingXchainLog = [];
+  return out;
+}
+
+/** Synchronous membership check — safe to call from render loops. */
+export function hasSableye(bareName: string): boolean {
+  if (!bareName) return false;
+  return _set.has(bareName.toLowerCase());
+}
+
+/**
+ * Record an interaction with a counterparty. Idempotent — adding an
+ * existing name just refreshes the lastTouch timestamp. Persists to
+ * Chronicom with a 2s debounce so a burst of 10 thunders costs one
+ * round-trip, not ten.
+ */
+export function noteCounterparty(bareName: string, chain: Chain): void {
+  if (!bareName) return;
+  const name = bareName.replace(/\.sui$/, '').toLowerCase();
+  if (!name) return;
+  let changed = false;
+  if (!_set.has(name)) {
+    _set.add(name);
+    _payload.names.push(name);
+    // Cap the set to prevent unbounded growth. Drop the least-recently
+    // touched entry. Rare in practice but keeps the ciphertext bounded.
+    if (_payload.names.length > _MAX_NAMES) {
+      let oldestName = _payload.names[0];
+      let oldestTs = _payload.lastTouch[oldestName] ?? 0;
+      for (const n of _payload.names) {
+        const ts = _payload.lastTouch[n] ?? 0;
+        if (ts < oldestTs) { oldestName = n; oldestTs = ts; }
+      }
+      _set.delete(oldestName);
+      _payload.names = _payload.names.filter(n => n !== oldestName);
+      delete _payload.lastTouch[oldestName];
+      for (const c of Object.keys(_payload.byChain) as Chain[]) {
+        _payload.byChain[c] = (_payload.byChain[c] || []).filter(n => n !== oldestName);
+      }
+    }
+    changed = true;
+  }
+  const chainList = _payload.byChain[chain] || [];
+  if (!chainList.includes(name)) {
+    chainList.push(name);
+    _payload.byChain[chain] = chainList;
+    changed = true;
+  }
+  const prevTs = _payload.lastTouch[name] ?? 0;
+  const now = Date.now();
+  if (now - prevTs > 60_000) {
+    // Throttle lastTouch bumps to once per minute per name — avoids
+    // gratuitous persist churn when a single session fires many events.
+    _payload.lastTouch[name] = now;
+    changed = true;
+  }
+  if (changed) _schedulePersist();
+}
+
+/** Force an immediate persist — used on disconnect or navigation. */
+export async function flushSableye(): Promise<void> {
+  if (_persistTimer) { clearTimeout(_persistTimer); _persistTimer = null; }
+  if (!_dirty) return;
+  await _persist();
+}
+
+/** Clear in-memory state on disconnect. Does NOT clear Chronicom cipher. */
+export function resetSableye(): void {
+  _ownerAddr = '';
+  _set = new Set();
+  _payload = { names: [], byChain: {}, lastTouch: {} };
+  _pendingXchainLog = [];
+  if (_persistTimer) { clearTimeout(_persistTimer); _persistTimer = null; }
+  _dirty = false;
+}
+
+function _schedulePersist(): void {
+  _dirty = true;
+  if (_persistTimer) clearTimeout(_persistTimer);
+  _persistTimer = setTimeout(() => { _persist().catch(() => {}); }, _PERSIST_DEBOUNCE_MS);
+}
+
+async function _persist(): Promise<void> {
+  if (!_ownerAddr) return;
+  const cipher = await _encrypt(_payload);
+  if (!cipher) return;
+  try {
+    const r = await fetch(_chronicomUrl(), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cipher }),
+    });
+    if (r.ok) _dirty = false;
+  } catch { /* non-blocking */ }
+}

--- a/src/client/thunder-stack.ts
+++ b/src/client/thunder-stack.ts
@@ -533,6 +533,17 @@ export async function sendThunder(opts: {
 }): Promise<{ messageId: string }> {
   const groupId = 'uuid' in opts.groupRef ? opts.groupRef.uuid : '';
 
+  // Sableye hook — fire a one-shot browser event the moment we know
+  // the recipient. ui layer listens and records the counterparty in
+  // the Seal-encrypted private interaction set. See issue #145.
+  if (opts.recipientName && typeof window !== 'undefined') {
+    try {
+      window.dispatchEvent(new CustomEvent('ski:thunder-sent', {
+        detail: { recipientName: opts.recipientName },
+      }));
+    } catch { /* non-blocking */ }
+  }
+
   const client = getThunderClient();
   const hasTransfer = opts.transfer && opts.transfer.amountMist > 0n && opts.signAndExecute;
   const hasIusdTransfer = opts.iusdTransfer && opts.iusdTransfer.amountMist > 0n && opts.signAndExecute;

--- a/src/server/agents/chronicom.ts
+++ b/src/server/agents/chronicom.ts
@@ -13,11 +13,27 @@ import { Agent } from 'agents';
 const ALARM_INTERVAL_MS = 5_000;
 const INACTIVITY_TIMEOUT_MS = 120_000;
 
+interface SableyeXchainEntry {
+  fromAddress: string;
+  chain: 'sol' | 'eth' | 'btc';
+  ts: number;
+  txHash?: string;
+}
+
+interface SableyeSlice {
+  cipher?: string;
+  updatedAt?: number;
+  xchainLog?: SableyeXchainEntry[];
+}
+
+const SABLEYE_XCHAIN_LOG_CAP = 200;
+
 interface ChronicomState {
   counts: Record<string, number>;
   names: string[];
   lastPollMs: number;
   alarmActive: boolean;
+  sableye?: SableyeSlice;
 }
 
 interface Env {
@@ -30,6 +46,7 @@ export class Chronicom extends Agent<Env, ChronicomState> {
     names: [],
     lastPollMs: 0,
     alarmActive: false,
+    sableye: { cipher: undefined, updatedAt: undefined, xchainLog: [] },
   };
 
   constructor(ctx: DurableObjectState, env: Env) {
@@ -85,6 +102,64 @@ export class Chronicom extends Agent<Env, ChronicomState> {
       }
 
       return Response.json(this.state.counts);
+    }
+
+    // ── Sableye Lv.10 — Leer ─────────────────────────────────────────────
+    // Seal-encrypted counterparty set. The DO never sees plaintext; it
+    // persists the ciphertext blob as-is and exposes an xchainLog that is
+    // appended to by webhook handlers (Astonish) when cross-chain credits
+    // from known counterparties land.
+    if (url.pathname.endsWith('/sableye') || url.searchParams.has('sableye')) {
+      if (request.method === 'GET') {
+        const s = this.state.sableye ?? {};
+        return Response.json({
+          cipher: s.cipher ?? null,
+          updatedAt: s.updatedAt ?? 0,
+          xchainLog: s.xchainLog ?? [],
+        });
+      }
+      if (request.method === 'POST') {
+        let body: { cipher?: unknown };
+        try { body = await request.json() as { cipher?: unknown }; }
+        catch { return Response.json({ error: 'invalid json' }, { status: 400 }); }
+        if (typeof body.cipher !== 'string' || body.cipher.length === 0) {
+          return Response.json({ error: 'cipher must be a non-empty string' }, { status: 400 });
+        }
+        const prev = this.state.sableye ?? {};
+        const next: SableyeSlice = {
+          cipher: body.cipher,
+          updatedAt: Date.now(),
+          xchainLog: prev.xchainLog ?? [],
+        };
+        this.setState({ ...this.state, sableye: next });
+        return Response.json({ ok: true, updatedAt: next.updatedAt });
+      }
+    }
+
+    // ── Sableye Lv.40 — Astonish ─────────────────────────────────────────
+    // Internal append route for webhook handlers. Takes a single entry
+    // `{ fromAddress, chain, ts?, txHash? }` and pushes it to xchainLog,
+    // capped at SABLEYE_XCHAIN_LOG_CAP (oldest dropped).
+    if (request.method === 'POST' && (url.pathname.endsWith('/sableye-xchain-append') || url.searchParams.has('sableye-xchain-append'))) {
+      let body: Partial<SableyeXchainEntry>;
+      try { body = await request.json() as Partial<SableyeXchainEntry>; }
+      catch { return Response.json({ error: 'invalid json' }, { status: 400 }); }
+      const fromAddress = typeof body.fromAddress === 'string' ? body.fromAddress : '';
+      const chain = body.chain;
+      if (!fromAddress || (chain !== 'sol' && chain !== 'eth' && chain !== 'btc')) {
+        return Response.json({ error: 'fromAddress + chain required' }, { status: 400 });
+      }
+      const entry: SableyeXchainEntry = {
+        fromAddress,
+        chain,
+        ts: typeof body.ts === 'number' ? body.ts : Date.now(),
+        ...(typeof body.txHash === 'string' ? { txHash: body.txHash } : {}),
+      };
+      const prev = this.state.sableye ?? {};
+      const log = [...(prev.xchainLog ?? []), entry];
+      while (log.length > SABLEYE_XCHAIN_LOG_CAP) log.shift();
+      this.setState({ ...this.state, sableye: { ...prev, xchainLog: log } });
+      return Response.json({ ok: true, size: log.length });
     }
 
     return Response.json(this.state.counts);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1798,6 +1798,39 @@ app.get('/api/thunder/chronicom', async (c) => {
   catch { return c.json({ error: text }, 500); }
 });
 
+// ── Sableye Lv.10 — Leer ──────────────────────────────────────────────
+// Seal-encrypted counterparty set per wallet. The worker proxies the
+// ciphertext blob to the owner's Chronicom DO as-is; only the browser
+// (with Seal decrypt keys) ever sees plaintext. Consistent with the
+// existing public chronicom surface — no new auth middleware.
+app.get('/api/chronicom/sableye', async (c) => {
+  const addr = c.req.query('addr');
+  if (!addr) return c.json({ error: 'addr required' }, 400);
+  const stub = c.env.Chronicom.get(c.env.Chronicom.idFromName(addr));
+  const res = await stub.fetch(new Request('https://chronicom-do/sableye', {
+    method: 'GET',
+    headers: { 'x-partykit-room': addr },
+  }));
+  const text = await res.text();
+  try { return c.json(JSON.parse(text), res.status as any); }
+  catch { return c.json({ error: text }, 500); }
+});
+
+app.post('/api/chronicom/sableye', async (c) => {
+  const addr = c.req.query('addr');
+  if (!addr) return c.json({ error: 'addr required' }, 400);
+  const body = await c.req.text();
+  const stub = c.env.Chronicom.get(c.env.Chronicom.idFromName(addr));
+  const res = await stub.fetch(new Request('https://chronicom-do/sableye', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-partykit-room': addr },
+    body,
+  }));
+  const text = await res.text();
+  try { return c.json(JSON.parse(text), res.status as any); }
+  catch { return c.json({ error: text }, 500); }
+});
+
 // NameIndex — global target-reverse map shared across all sui.ski visitors.
 // Client writes mappings whenever it resolves `@name → address`, and
 // reads them as a last-resort fallback when SuiNS primary + owned-NFT

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -3461,6 +3461,11 @@ let nsTransferRecipient = ''; // value in the transfer-recipient input
 // Thunder counts disabled — pending v4 migration (#63). Always empty.
 let _thunderCounts: Record<string, number> = {};
 
+// Sableye — module handle for synchronous roster lookup. Populated
+// after warmSableye() resolves. Null until then → roster renders
+// default blue squares and picks up diamonds on next open.
+let _sableyeMod: { hasSableye: (n: string) => boolean } | null = null;
+
 /** Transfer tx digests known to be settled (claimed or recalled).
  *  Populated by the click handler + the background settlement poll.
  *  Persisted to localStorage so re-renders, reloads, and cross-session
@@ -10724,7 +10729,14 @@ function bindEvents() {
       let _rosterWheelBound = false;
 
       const _renderRosterChip = ({ name, expirationMs, primary }: _RosterEntry) => {
-        const shape = _shapeOnlySvg('blue-square', 14);
+        // Sableye Lv.50 — black diamond for names in the private
+        // interaction set. Synchronous lookup against the warmed
+        // cache; falls back to blue square if cache not yet loaded.
+        const _bareChip = name.replace(/\.sui$/, '').toLowerCase();
+        const _isPrivate = (() => {
+          try { return _sableyeMod?.hasSableye?.(_bareChip) === true; } catch { return false; }
+        })();
+        const shape = _shapeOnlySvg(_isPrivate ? 'black-diamond' : 'blue-square', 14);
         let expiryTag = '';
         let itemCls = '';
         if (primary) itemCls += ' ski-idle-roster-item--primary';
@@ -15774,6 +15786,39 @@ export function initUI() {
           },
         });
         warmThunderSession().catch(() => {});
+      }).catch(() => {});
+
+      // Sableye — warm the encrypted private-interaction cache.
+      // See issue #145. One Chronicom fetch + local AES-GCM decrypt.
+      // The ski:thunder-sent event fires from sendThunder; ui records
+      // the counterparty immediately so the roster flips to black
+      // diamond on next render.
+      import('./client/sableye.js').then(async ({ warmSableye, noteCounterparty, drainXchainLog, hasSableye }) => {
+        _sableyeMod = { hasSableye };
+        await warmSableye(ws.address).catch(() => {});
+        window.addEventListener('ski:thunder-sent', (ev) => {
+          const name = ((ev as CustomEvent).detail?.recipientName ?? '') as string;
+          if (name) noteCounterparty(name, 'sui');
+        });
+        // Drain any server-side xchain webhook log (Sableye Lv.40
+        // lands separately with the Helius/Alchemy handlers) and
+        // map fromAddress → bare name via reverse lookup.
+        const pending = drainXchainLog();
+        if (pending.length > 0) {
+          try {
+            const { reverseLookupName } = await import('./client/thunder.js');
+            for (const entry of pending) {
+              try {
+                const name = await reverseLookupName(entry.fromAddress);
+                if (name) {
+                  const chain = entry.chain === 'sol' || entry.chain === 'eth' || entry.chain === 'btc'
+                    ? entry.chain : 'sui';
+                  noteCounterparty(name, chain);
+                }
+              } catch { /* per-entry best-effort */ }
+            }
+          } catch { /* reverseLookup unavailable */ }
+        }
       }).catch(() => {});
 
       // Execute Prism intent if one was stored from ?prism= URL


### PR DESCRIPTION
## Mega Sableye — ciphertext as a shield

Sableye's Mega form holds a massive black diamond as a shield, blocking all incoming attacks. The metaphor maps directly to this feature: the counterparty set lives as **AES-GCM ciphertext** in Chronicom, with the key **non-extractable** in browser IndexedDB. An operator dumping the DO state gets raw ciphertext and no way back to plaintext names.

Closes #145.

## What's here

### Lv.10 — Leer (cherry-picked from `ccad0a6`)
- Chronicom DO gains a `sableye` slice (ciphertext + updatedAt + xchainLog)
- Worker routes: `GET /api/chronicom/sableye?addr=...`, `POST /api/chronicom/sableye?addr=...`
- DO never sees plaintext — rejects non-string cipher, persists the rest verbatim

### Lv.20 — Shadow Sneak (authored on this branch)
- `src/client/sableye.ts` — full client with:
  - `warmSableye(addr)` — fetch + Seal-decrypt into in-memory cache
  - `noteCounterparty(name, chain)` — record an interaction, debounced persist (2s)
  - `hasSableye(name)` — synchronous lookup for render loops
  - `flushSableye()` / `resetSableye()` — lifecycle
- AES-GCM key: non-extractable, `crypto.subtle.generateKey` + IndexedDB store `ski-crypto/keys/sableye-aes`. Raw bits never leave the browser's crypto store.
- `sendThunder` in `thunder-stack.ts` dispatches `ski:thunder-sent` with the recipient name — ui listens once in the wallet-connect block.

### Lv.30 — Knock Off (authored on this branch)
- On warm, `drainXchainLog()` returns any pending webhook entries the server has captured
- Each fromAddress resolved via `reverseLookupName` → bare name → `noteCounterparty`
- Best-effort per entry; per-entry errors swallowed

### Lv.50 — Detect (authored on this branch)
- `_renderRosterChip` consults `hasSableye(bareName)` and swaps the default blue square for a black diamond when the name is in the private interaction set
- Module handle (`_sableyeMod`) stashed in module scope after warm so the render never awaits
- Falls back to blue square if the cache hasn't loaded yet — next roster open picks up the right glyph

## Deferred
- **Lv.40 Astonish** — Helius + Alchemy webhook `xchainLog` writers. Depends on nursery webhook infrastructure; lives in PR #132 as `870a18e`. Will land when nursery merges.
- **Lv.60 Foresight** — hover tooltip with interaction-type glyphs (⚡ thunder, 💸 transfer, 🌐 xchain). Minor polish.

## Test plan
- [ ] Connect wallet → `warmSableye(addr)` fires, `GET /api/chronicom/sableye` returns `{cipher:null}` on fresh accounts
- [ ] Send a Thunder to @recipient → `ski:thunder-sent` fires → `noteCounterparty` records → `_persist` debounces → Chronicom gets ciphertext after 2s
- [ ] Hard refresh, reopen overlay → `warmSableye` decrypts the ciphertext → roster shows @recipient with a black diamond
- [ ] GitGuardian + build + deploy all clean