### PR TITLE
Porygon evolves: Xatu + Magneton + Porygon CF enrichment substrate

### DIFF
--- a/contracts/suiami/sources/roster.move
+++ b/contracts/suiami/sources/roster.move
@@ -267,3 +267,123 @@ public fun has_cf_history(roster: &Roster, addr: address): bool {
     let key = CfHistoryKey { addr };
     dynamic_field::exists_<CfHistoryKey>(&roster.id, key)
 }
+
+// ─── Granular mutators ──────────────────────────────────────────────
+//
+// Update a single field without rewriting the whole record via
+// `set_identity`. Callers pass `name_hash` because it's not stored on
+// the record but is needed to locate the by_name index copy. Every
+// mutator propagates to all three dynamic-field indexes to prevent
+// drift.
+
+/// Rewrites name_hash / sui_address / chain:addr indexes with the same
+/// record bytes. Internal — mutators call this after updating fields.
+fun rewrite_indexes(roster_id: &mut UID, record: &IdentityRecord, name_hash: vector<u8>) {
+    if (dynamic_field::exists_<vector<u8>>(roster_id, name_hash)) {
+        dynamic_field::remove<vector<u8>, IdentityRecord>(roster_id, name_hash);
+    };
+    dynamic_field::add(roster_id, name_hash, *record);
+
+    let addr = record.sui_address;
+    if (dynamic_field::exists_<address>(roster_id, addr)) {
+        dynamic_field::remove<address, IdentityRecord>(roster_id, addr);
+    };
+    dynamic_field::add(roster_id, addr, *record);
+
+    let keys = record.chains.keys();
+    let len = keys.length();
+    let mut i = 0;
+    while (i < len) {
+        let chain_key = keys[i];
+        let chain_value = *record.chains.get(&chain_key);
+        let mut composite = chain_key;
+        composite.append_utf8(b":");
+        composite.append(chain_value);
+        if (dynamic_field::exists_<String>(roster_id, composite)) {
+            dynamic_field::remove<String, IdentityRecord>(roster_id, composite);
+        };
+        dynamic_field::add(roster_id, composite, *record);
+        i = i + 1;
+    };
+}
+
+/// Rotate Walrus blob id + Seal nonce. Caller must own the by_address
+/// record. Propagates to all three indexes.
+public fun set_walrus_blob(
+    roster: &mut Roster,
+    name_hash: vector<u8>,
+    blob_id: String,
+    seal_nonce: vector<u8>,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    let sender = ctx.sender();
+    assert!(dynamic_field::exists_<address>(&roster.id, sender), ENotOwner);
+    let current: &IdentityRecord = dynamic_field::borrow<address, IdentityRecord>(&roster.id, sender);
+    assert!(current.sui_address == sender, ENotOwner);
+    let mut updated: IdentityRecord = *current;
+    updated.walrus_blob_id = blob_id;
+    updated.seal_nonce = seal_nonce;
+    updated.updated_ms = clock.timestamp_ms();
+    rewrite_indexes(&mut roster.id, &updated, name_hash);
+}
+
+/// Replace dWallet caps (flips `verified` based on non-emptiness).
+/// Caller must own the by_address record.
+public fun set_dwallet_caps(
+    roster: &mut Roster,
+    name_hash: vector<u8>,
+    caps: vector<address>,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    let sender = ctx.sender();
+    assert!(dynamic_field::exists_<address>(&roster.id, sender), ENotOwner);
+    let current: &IdentityRecord = dynamic_field::borrow<address, IdentityRecord>(&roster.id, sender);
+    assert!(current.sui_address == sender, ENotOwner);
+    let mut updated: IdentityRecord = *current;
+    updated.dwallet_caps = caps;
+    updated.verified = !updated.dwallet_caps.is_empty();
+    updated.updated_ms = clock.timestamp_ms();
+    rewrite_indexes(&mut roster.id, &updated, name_hash);
+}
+
+/// Feint the identity — removes all three index copies + any
+/// cf_history store. Decrements the global count. Caller must own the
+/// by_address record.
+public fun revoke_identity(
+    roster: &mut Roster,
+    name_hash: vector<u8>,
+    ctx: &TxContext,
+) {
+    let sender = ctx.sender();
+    assert!(dynamic_field::exists_<address>(&roster.id, sender), ENotOwner);
+    let record: IdentityRecord = dynamic_field::remove<address, IdentityRecord>(&mut roster.id, sender);
+    assert!(record.sui_address == sender, ENotOwner);
+
+    if (dynamic_field::exists_<vector<u8>>(&roster.id, name_hash)) {
+        dynamic_field::remove<vector<u8>, IdentityRecord>(&mut roster.id, name_hash);
+    };
+
+    let keys = record.chains.keys();
+    let len = keys.length();
+    let mut i = 0;
+    while (i < len) {
+        let chain_key = keys[i];
+        let chain_value = *record.chains.get(&chain_key);
+        let mut composite = chain_key;
+        composite.append_utf8(b":");
+        composite.append(chain_value);
+        if (dynamic_field::exists_<String>(&roster.id, composite)) {
+            dynamic_field::remove<String, IdentityRecord>(&mut roster.id, composite);
+        };
+        i = i + 1;
+    };
+
+    let cf_key = CfHistoryKey { addr: sender };
+    if (dynamic_field::exists_<CfHistoryKey>(&roster.id, cf_key)) {
+        dynamic_field::remove<CfHistoryKey, CfHistory>(&mut roster.id, cf_key);
+    };
+
+    roster.count = roster.count - 1;
+}

--- a/contracts/suiami/sources/roster.move
+++ b/contracts/suiami/sources/roster.move
@@ -204,3 +204,66 @@ public fun record_updated_ms(record: &IdentityRecord): u64 { record.updated_ms }
 public fun record_walrus_blob_id(record: &IdentityRecord): &String { &record.walrus_blob_id }
 public fun record_seal_nonce(record: &IdentityRecord): &vector<u8> { &record.seal_nonce }
 public fun record_verified(record: &IdentityRecord): bool { record.verified }
+
+// ─── CF edge history (Porygon) ──────────────────────────────────────
+//
+// Append-only log of Seal-sealed Walrus blob IDs, one per CF fingerprint
+// change. Stored as a separate dynamic field keyed by wallet address so
+// the additive upgrade doesn't touch IdentityRecord's BCS shape. Client
+// does change detection before appending (typical user: 1-3 lifetime
+// entries).
+
+/// Dynamic-field key for per-address CF history store.
+public struct CfHistoryKey has copy, drop, store { addr: address }
+
+/// CF-history container. `blobs` is oldest-first.
+public struct CfHistory has store, drop {
+    blobs: vector<String>,
+    updated_ms: u64,
+}
+
+/// Append a Walrus blob ID to the caller's CF history. Creates the
+/// history store on first write. Asserts the caller has a roster
+/// record (prevents anonymous writes from consuming storage).
+public fun append_cf_history(
+    roster: &mut Roster,
+    blob_id: String,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    let sender = ctx.sender();
+    assert!(dynamic_field::exists_<address>(&roster.id, sender), ENotOwner);
+    let key = CfHistoryKey { addr: sender };
+    if (dynamic_field::exists_<CfHistoryKey>(&roster.id, key)) {
+        let history: &mut CfHistory = dynamic_field::borrow_mut(&mut roster.id, key);
+        history.blobs.push_back(blob_id);
+        history.updated_ms = clock.timestamp_ms();
+    } else {
+        let mut blobs = vector::empty<String>();
+        blobs.push_back(blob_id);
+        dynamic_field::add(&mut roster.id, key, CfHistory {
+            blobs,
+            updated_ms: clock.timestamp_ms(),
+        });
+    };
+}
+
+/// Read the caller's or any address's CF history blob IDs.
+public fun cf_history(roster: &Roster, addr: address): &vector<String> {
+    let key = CfHistoryKey { addr };
+    let h: &CfHistory = dynamic_field::borrow(&roster.id, key);
+    &h.blobs
+}
+
+/// Last-updated timestamp of the CF history store.
+public fun cf_history_updated_ms(roster: &Roster, addr: address): u64 {
+    let key = CfHistoryKey { addr };
+    let h: &CfHistory = dynamic_field::borrow(&roster.id, key);
+    h.updated_ms
+}
+
+/// Does this address have any CF history? Checked by Seal policy.
+public fun has_cf_history(roster: &Roster, addr: address): bool {
+    let key = CfHistoryKey { addr };
+    dynamic_field::exists_<CfHistoryKey>(&roster.id, key)
+}

--- a/contracts/suiami/sources/seal_roster.move
+++ b/contracts/suiami/sources/seal_roster.move
@@ -19,9 +19,20 @@ entry fun seal_approve_roster_reader(
     ctx: &TxContext,
 ) {
     assert!(id.length() == 40, EInvalidIdentity);
-    assert!(roster::has_address(roster, ctx.sender()), ENotRegistered);
-    let record = roster::lookup_by_address(roster, ctx.sender());
+    let sender = ctx.sender();
+    assert!(roster::has_address(roster, sender), ENotRegistered);
+    let record = roster::lookup_by_address(roster, sender);
     assert!(roster::record_walrus_blob_id(record).length() > 0, ENoEncryptedData);
+    // Tightened: id prefix must match caller's address bytes so a
+    // holder can't sign decrypt on a Seal id scoped to a different
+    // member. Harmless today (mutual policy still lets them in) but
+    // future-proofs if mutual semantics ever narrow.
+    let addr_bytes = sui::address::to_bytes(sender);
+    let mut i = 0u64;
+    while (i < 32) {
+        assert!(*id.borrow(i) == *addr_bytes.borrow(i), EInvalidIdentity);
+        i = i + 1;
+    };
 }
 
 /// Personal CF-history decrypt policy. Only the record owner can

--- a/contracts/suiami/sources/seal_roster.move
+++ b/contracts/suiami/sources/seal_roster.move
@@ -23,3 +23,25 @@ entry fun seal_approve_roster_reader(
     let record = roster::lookup_by_address(roster, ctx.sender());
     assert!(roster::record_walrus_blob_id(record).length() > 0, ENoEncryptedData);
 }
+
+/// Personal CF-history decrypt policy. Only the record owner can
+/// decrypt their own CF chunks — not mutual-decrypt like the roster
+/// reader policy. Seal id layout: 32-byte sender address ‖ 8-byte nonce.
+entry fun seal_approve_cf_history(
+    roster: &Roster,
+    id: vector<u8>,
+    ctx: &TxContext,
+) {
+    assert!(id.length() == 40, EInvalidIdentity);
+    let sender = ctx.sender();
+    assert!(roster::has_cf_history(roster, sender), ENoEncryptedData);
+    // Id prefix must be the sender's address bytes — prevents a caller
+    // from passing someone else's Seal id even though policy is scoped
+    // to their own address.
+    let addr_bytes = sui::address::to_bytes(sender);
+    let mut i = 0u64;
+    while (i < 32) {
+        assert!(*id.borrow(i) == *addr_bytes.borrow(i), ENotRegistered);
+        i = i + 1;
+    };
+}

--- a/docs/superpowers/plans/2026-04-16-cf-edge-enrichment.md
+++ b/docs/superpowers/plans/2026-04-16-cf-edge-enrichment.md
@@ -1,0 +1,757 @@
+# CF Edge Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture Cloudflare edge metadata on every SUIAMI squid-blob-bearing write, store as a Seal-sealed Walrus chunk under a personal-decrypt policy, with client-side change detection so typical users produce 1–3 lifetime chunks.
+
+**Architecture:** Move contract gets one field (`cf_history: vector<String>`) and two entries (`append_cf_history`, `seal_approve_cf_history`). Worker exposes `/api/cf-context` returning HMAC-signed CF fields. Client fingerprints → compares against tail chunk → Seal-encrypts → uploads to Walrus → appends blob ID in the same PTB as the existing roster write.
+
+**Tech Stack:** Move (Sui), Cloudflare Workers, `@mysten/sui` v2, `@mysten/seal`, `@mysten/walrus`, Bun, TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-cf-edge-enrichment-design.md`
+
+---
+
+### Task 1: Extend IdentityRecord struct with cf_history field
+
+**Files:**
+- Modify: `contracts/suiami/sources/roster.move:49-69` (struct definition) + add getter
+
+- [ ] **Step 1: Add `cf_history: vector<String>` to IdentityRecord struct**
+
+In `contracts/suiami/sources/roster.move`, locate `public struct IdentityRecord has store, drop, copy { ... }` and add the field after `verified: bool`:
+
+```move
+public struct IdentityRecord has store, drop, copy {
+    name: String,
+    sui_address: address,
+    chains: VecMap<String, String>,
+    dwallet_caps: vector<address>,
+    walrus_blob_id: String,
+    seal_nonce: vector<u8>,
+    verified: bool,
+    cf_history: vector<String>,  // NEW: oldest-first Walrus blob IDs
+    updated_ms: u64,
+}
+```
+
+- [ ] **Step 2: Initialize `cf_history` in `set_identity`**
+
+Find the `set_identity` entry fun body and the record-construction site. When the record is created, initialize the new field to an empty vector:
+
+```move
+cf_history: vector::empty<String>(),
+```
+
+If `set_identity` mutates an existing record rather than constructing a new one, ensure the empty-vector default is preserved for new records only. Do NOT touch existing records' `cf_history` in this entry.
+
+- [ ] **Step 3: Add the getter after `record_verified`**
+
+Below line ~206 in `roster.move`:
+
+```move
+public fun record_cf_history(record: &IdentityRecord): &vector<String> { &record.cf_history }
+```
+
+- [ ] **Step 4: Build the contract**
+
+Run: `cd contracts/suiami && sui move build 2>&1 | tail -20`
+Expected: `BUILDING suiami` with no errors. If existing callers fail to pattern-match the struct, update them to include `cf_history: vector::empty()` in the same PTB.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add contracts/suiami/sources/roster.move
+git commit -m "suiami: add cf_history field to IdentityRecord"
+```
+
+---
+
+### Task 2: Add append_cf_history entry function
+
+**Files:**
+- Modify: `contracts/suiami/sources/roster.move` (add entry fun)
+
+- [ ] **Step 1: Append the entry function at the end of `roster.move`**
+
+```move
+/// Append a Walrus blob ID to the caller's CF history. Only the record
+/// owner (sui_address) can call. No size cap — client-side change
+/// detection keeps typical users at 1-3 lifetime entries.
+public entry fun append_cf_history(
+    roster: &mut Roster,
+    blob_id: String,
+    clock: &Clock,
+    ctx: &TxContext,
+) {
+    let sender = tx_context::sender(ctx);
+    assert!(has_address(roster, sender), ENotOwner);
+    let record = table::borrow_mut(&mut roster.by_address, sender);
+    vector::push_back(&mut record.cf_history, blob_id);
+    record.updated_ms = clock::timestamp_ms(clock);
+}
+```
+
+Note: confirm the actual table lookup method matches existing code in `roster.move`. If `lookup_by_address` is public and takes `&Roster`, introduce a mirror `lookup_by_address_mut` or adapt the call. Read `roster.move:168-193` first to match the pattern.
+
+- [ ] **Step 2: Build the contract**
+
+Run: `cd contracts/suiami && sui move build 2>&1 | tail -10`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add contracts/suiami/sources/roster.move
+git commit -m "suiami: append_cf_history entry"
+```
+
+---
+
+### Task 3: Add seal_approve_cf_history policy
+
+**Files:**
+- Modify: `contracts/suiami/sources/seal_roster.move` (add entry fun)
+
+- [ ] **Step 1: Read the existing `seal_approve_roster_reader` pattern**
+
+Run: `cat contracts/suiami/sources/seal_roster.move`
+Note the exact id-prefix check, the `ENotAuthorized` constant, and how `assert!(record_walrus_blob_id(record).length() > 0, ENoEncryptedData)` is expressed.
+
+- [ ] **Step 2: Append the new policy entry at end of `seal_roster.move`**
+
+```move
+/// Personal CF-history decrypt policy. Authorizes iff the caller is the
+/// record owner AND the record has at least one cf_history entry.
+/// Id prefix check mirrors seal_approve_roster_reader.
+entry fun seal_approve_cf_history(
+    id: vector<u8>,
+    roster: &Roster,
+    ctx: &TxContext,
+) {
+    let sender = tx_context::sender(ctx);
+    assert!(suiami::roster::has_address(roster, sender), ENotAuthorized);
+    let record = suiami::roster::lookup_by_address(roster, sender);
+    assert!(vector::length(suiami::roster::record_cf_history(record)) > 0, ENoEncryptedData);
+    // Id must begin with the record's sui_address bytes (Seal identity prefix).
+    let addr_bytes = sui::address::to_bytes(suiami::roster::record_sui_address(record));
+    let id_len = vector::length(&id);
+    let prefix_len = vector::length(&addr_bytes);
+    assert!(id_len >= prefix_len, ENotAuthorized);
+    let mut i = 0u64;
+    while (i < prefix_len) {
+        assert!(*vector::borrow(&id, i) == *vector::borrow(&addr_bytes, i), ENotAuthorized);
+        i = i + 1;
+    };
+}
+```
+
+If `ENotAuthorized` or `ENoEncryptedData` aren't already defined, reuse the existing constants verified in Step 1 — do NOT duplicate.
+
+- [ ] **Step 3: Build**
+
+Run: `cd contracts/suiami && sui move build 2>&1 | tail -10`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add contracts/suiami/sources/seal_roster.move
+git commit -m "suiami: seal_approve_cf_history personal policy"
+```
+
+---
+
+### Task 4: Publish contract upgrade
+
+**Files:**
+- None (uses existing UpgradeCap tracked in memory under `project_iusd_upgrade_cap.md` or suiami equivalent)
+
+- [ ] **Step 1: Locate suiami UpgradeCap**
+
+Run: `sui client objects --json 2>/dev/null | jq -r '.[] | select(.data.type | test("UpgradeCap")) | .data.objectId + " " + (.data.type // "")' 2>&1 | head -20`
+Pick the UpgradeCap whose type references the suiami package. If unclear, check `~/.claude/projects/-home-brandon-Dev-Sui-Dev-Projects-SKI/memory/` for an existing suiami upgrade-cap memory.
+
+- [ ] **Step 2: Run the upgrade**
+
+Run: `cd contracts/suiami && sui client upgrade --upgrade-capability <CAP_ID> --gas-budget 200000000 2>&1 | tail -30`
+Expected: `Status: Success` and a new package ID in the output. Record the NEW package ID.
+
+- [ ] **Step 3: Update client config with new package ID**
+
+Find where the suiami package ID is referenced in client code:
+Run: `grep -rn "suiami::roster\|SUIAMI_PACKAGE" src/ 2>&1 | head -10`
+Update each reference (or the central constant) to the new package ID.
+
+- [ ] **Step 4: Build + sanity-check**
+
+Run: `bun run build 2>&1 | tail -5`
+Expected: clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "suiami: publish cf_history upgrade, wire client to new package id"
+```
+
+---
+
+### Task 5: Worker endpoint `/api/cf-context`
+
+**Files:**
+- Create: `src/server/cf-context.ts`
+- Modify: `src/server/index.ts` (add route)
+- Modify: `wrangler.toml` (env var placeholders)
+
+- [ ] **Step 1: Add env vars to wrangler.toml**
+
+In `wrangler.toml`, under `[vars]` (or the appropriate section for non-secret vars), add:
+
+```toml
+# CF_HMAC_SECRET and CF_IP_SALT are injected via `wrangler secret put`.
+# Do NOT commit secret values. These placeholders document the dependency.
+```
+
+Then run the secret puts (prompt for user to paste values):
+
+```bash
+echo "Set CF_HMAC_SECRET (32+ random chars):" && npx wrangler secret put CF_HMAC_SECRET
+echo "Set CF_IP_SALT (32+ random chars):" && npx wrangler secret put CF_IP_SALT
+```
+
+- [ ] **Step 2: Create `src/server/cf-context.ts`**
+
+```typescript
+// CF edge context endpoint for SUIAMI CF-history enrichment.
+// Returns HMAC-signed CF metadata the client encrypts + uploads to Walrus.
+
+export interface CfFields {
+  country: string;
+  asn: number;
+  threatScore: number;
+  ipHash: string;       // hex, SHA-256(salt ‖ ip)
+  colo: string;
+  verifiedBot: boolean;
+  tlsVersion: string;
+  httpProtocol: string;
+  attestedAt: number;   // ms epoch
+}
+
+export interface CfContextResponse {
+  data: CfFields;
+  sig: string;          // hex HMAC-SHA256 over canonical JSON of data
+}
+
+/** Canonical JSON — sorted keys, no whitespace. Stable across clients. */
+function canonicalize(data: CfFields): string {
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(data).sort()) sorted[k] = (data as unknown as Record<string, unknown>)[k];
+  return JSON.stringify(sorted);
+}
+
+async function hmac(secret: string, msg: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(msg));
+  return [...new Uint8Array(sig)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function handleCfContext(req: Request, env: { CF_HMAC_SECRET?: string; CF_IP_SALT?: string }): Promise<Response> {
+  if (!env.CF_HMAC_SECRET || !env.CF_IP_SALT) {
+    return new Response(JSON.stringify({ error: 'cf-context not configured' }), { status: 500, headers: { 'content-type': 'application/json' } });
+  }
+  const cf = (req as unknown as { cf?: Record<string, unknown> }).cf ?? {};
+  const ip = req.headers.get('cf-connecting-ip') ?? '';
+  const data: CfFields = {
+    country: String(req.headers.get('cf-ipcountry') ?? cf.country ?? 'XX'),
+    asn: Number(cf.asn ?? 0),
+    threatScore: Number(cf.threatScore ?? 0),
+    ipHash: ip ? await sha256Hex(env.CF_IP_SALT + '\x1f' + ip) : '',
+    colo: String(cf.colo ?? ''),
+    verifiedBot: Boolean(cf.verifiedBot ?? false),
+    tlsVersion: String(cf.tlsVersion ?? ''),
+    httpProtocol: String(cf.httpProtocol ?? ''),
+    attestedAt: Date.now(),
+  };
+  const sig = await hmac(env.CF_HMAC_SECRET, canonicalize(data));
+  return new Response(JSON.stringify({ data, sig }), {
+    headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+  });
+}
+```
+
+- [ ] **Step 3: Wire the route in `src/server/index.ts`**
+
+Find the existing URL-pathname routing block (around line 248, `url.pathname` comparisons). Add a branch:
+
+```typescript
+if (url.pathname === '/api/cf-context') {
+  const { handleCfContext } = await import('./cf-context');
+  return handleCfContext(request, env as { CF_HMAC_SECRET?: string; CF_IP_SALT?: string });
+}
+```
+
+Place it alongside the other `/api/` routes.
+
+- [ ] **Step 4: Build + deploy**
+
+Run: `bun run build && npx wrangler deploy 2>&1 | tail -10`
+Expected: deploy success, new Version ID printed.
+
+- [ ] **Step 5: Smoke-test**
+
+Run: `curl -s https://sui.ski/api/cf-context | jq .`
+Expected: JSON with `data.country`, `data.colo`, `data.asn` populated, `sig` is 64 hex chars.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/cf-context.ts src/server/index.ts wrangler.toml
+git commit -m "worker: /api/cf-context HMAC-signed CF edge metadata"
+```
+
+---
+
+### Task 6: Client `src/client/cf-history.ts`
+
+**Files:**
+- Create: `src/client/cf-history.ts`
+
+- [ ] **Step 1: Write the module**
+
+```typescript
+// CF edge enrichment client — fetches signed CF metadata from the worker,
+// change-detects against the tail chunk, Seal-encrypts, uploads to Walrus,
+// and returns the new blob ID for inclusion in a roster write PTB.
+
+import type { Transaction } from '@mysten/sui/transactions';
+
+export interface CfFields {
+  country: string;
+  asn: number;
+  threatScore: number;
+  ipHash: string;
+  colo: string;
+  verifiedBot: boolean;
+  tlsVersion: string;
+  httpProtocol: string;
+  attestedAt: number;
+}
+export interface CfEnvelope { data: CfFields; sig: string }
+export interface CfChunk { schema: 1; data: CfFields; sig: string }
+
+const WALRUS_PUBLISHER = 'https://publisher.walrus-testnet.walrus.space';
+const WALRUS_AGGREGATOR = 'https://aggregator.walrus-testnet.walrus.space';
+
+/** Fields compared for change detection (everything except attestedAt). */
+const CHANGE_KEYS: Array<keyof CfFields> = [
+  'country', 'asn', 'threatScore', 'ipHash', 'colo',
+  'verifiedBot', 'tlsVersion', 'httpProtocol',
+];
+
+function fingerprintsMatch(a: CfFields, b: CfFields): boolean {
+  return CHANGE_KEYS.every(k => a[k] === b[k]);
+}
+
+export async function fetchCfContext(): Promise<CfEnvelope | null> {
+  try {
+    const res = await fetch('/api/cf-context');
+    if (!res.ok) return null;
+    return await res.json() as CfEnvelope;
+  } catch { return null; }
+}
+
+/** Decrypt the tail chunk to compare fingerprints. Returns null on any failure. */
+async function decryptTailChunk(tailBlobId: string): Promise<CfFields | null> {
+  try {
+    const res = await fetch(`${WALRUS_AGGREGATOR}/v1/blobs/${tailBlobId}`);
+    if (!res.ok) return null;
+    const encrypted = new Uint8Array(await res.arrayBuffer());
+    const { decryptCfChunkBytes } = await import('./cf-history-seal');
+    const chunk = await decryptCfChunkBytes(encrypted);
+    return chunk?.data ?? null;
+  } catch { return null; }
+}
+
+/**
+ * Decide whether to write a new CF chunk, and if so return the Walrus blob
+ * ID of the freshly uploaded+encrypted chunk. Callers then pass this ID to
+ * `append_cf_history` in the same PTB as their existing roster write.
+ *
+ * @param ownerAddress user's Sui address (sender of the enclosing PTB)
+ * @param tailBlobId   most recent entry in `cf_history`, or empty string
+ */
+export async function maybeBuildCfChunk(
+  ownerAddress: string,
+  tailBlobId: string,
+): Promise<string | null> {
+  const env = await fetchCfContext();
+  if (!env) return null;
+  if (tailBlobId) {
+    const prev = await decryptTailChunk(tailBlobId);
+    if (prev && fingerprintsMatch(prev, env.data)) return null;
+  }
+  const { encryptCfChunkToWalrus } = await import('./cf-history-seal');
+  const { blobId } = await encryptCfChunkToWalrus(ownerAddress, {
+    schema: 1, data: env.data, sig: env.sig,
+  });
+  return blobId;
+}
+
+export { WALRUS_PUBLISHER, WALRUS_AGGREGATOR };
+```
+
+- [ ] **Step 2: Commit (module stub, depends on seal helper from Task 7)**
+
+```bash
+git add src/client/cf-history.ts
+git commit -m "client: cf-history module (depends on cf-history-seal helper)"
+```
+
+---
+
+### Task 7: Seal encrypt/decrypt helper `src/client/cf-history-seal.ts`
+
+**Files:**
+- Create: `src/client/cf-history-seal.ts`
+
+- [ ] **Step 1: Read existing seal wrapper**
+
+Run: `grep -n "sealRace\|SessionKey\|SealClient\|encrypt\|decrypt" src/client/suiami-seal.ts | head -30`
+Note the `sealRace`, `SessionKey` mint/import helpers, and package ID references.
+
+- [ ] **Step 2: Write the module**
+
+```typescript
+// CF-history Seal encryption — mirrors suiami-seal.ts but targets the
+// personal `seal_approve_cf_history` policy (only the record owner can
+// decrypt, not mutual-decrypt).
+
+import { bcs } from '@mysten/sui/bcs';
+import { normalizeSuiAddress } from '@mysten/sui/utils';
+import { sealRace, buildPersonalSessionKey } from './suiami-seal';
+// NOTE: if buildPersonalSessionKey does not exist, use getOrMintSessionKey
+//       and check the exact export from suiami-seal.ts before writing this
+//       import. Same for sealRace. Update imports to match.
+
+import type { CfChunk } from './cf-history';
+
+const WALRUS_PUBLISHER = 'https://publisher.walrus-testnet.walrus.space';
+
+/** Build the 40-byte Seal id: address bytes ‖ 8-byte random nonce. */
+function buildSealId(ownerAddress: string): Uint8Array {
+  const addrBytes = bcs.Address.serialize(normalizeSuiAddress(ownerAddress)).toBytes();
+  const nonce = crypto.getRandomValues(new Uint8Array(8));
+  const id = new Uint8Array(addrBytes.length + nonce.length);
+  id.set(addrBytes, 0);
+  id.set(nonce, addrBytes.length);
+  return id;
+}
+
+export async function encryptCfChunkToWalrus(
+  ownerAddress: string,
+  chunk: CfChunk,
+): Promise<{ blobId: string; sealId: Uint8Array }> {
+  const sealId = buildSealId(ownerAddress);
+  const plaintext = new TextEncoder().encode(JSON.stringify(chunk));
+  // Seal id is already hex-prefixed by the package; pass raw bytes to encrypt.
+  const { encryptedObject } = await sealRace((c) =>
+    c.encrypt({
+      packageId: (await import('./suiami-seal')).SUIAMI_PACKAGE_ID,
+      id: sealId,
+      threshold: 2,
+      data: plaintext,
+    }),
+  );
+  const res = await fetch(`${WALRUS_PUBLISHER}/v1/blobs`, {
+    method: 'PUT',
+    body: encryptedObject,
+  });
+  if (!res.ok) throw new Error(`Walrus upload failed: ${res.status}`);
+  const j = await res.json();
+  const blobId = j?.newlyCreated?.blobObject?.blobId ?? j?.alreadyCertified?.blobId;
+  if (!blobId) throw new Error('Walrus: no blobId in response');
+  return { blobId: blobId as string, sealId };
+}
+
+export async function decryptCfChunkBytes(encryptedObject: Uint8Array): Promise<CfChunk | null> {
+  try {
+    const { decryptWithPersonalPolicy } = await import('./suiami-seal');
+    // Use the personal policy wrapper — it should call the Move
+    // `seal_approve_cf_history` entry during dry-run. If suiami-seal.ts
+    // currently only has `decryptWithRosterPolicy`, add a parallel helper
+    // that swaps in `seal_approve_cf_history` as the policy function name.
+    const plaintext = await decryptWithPersonalPolicy(encryptedObject);
+    if (!plaintext) return null;
+    return JSON.parse(new TextDecoder().decode(plaintext)) as CfChunk;
+  } catch {
+    return null;
+  }
+}
+```
+
+**CRITICAL:** Before writing this file, open `src/client/suiami-seal.ts` and confirm the exact names of the exports used (`sealRace`, `SUIAMI_PACKAGE_ID`, any session-key helpers). Swap to real names. If the file only exposes a roster-policy decrypt, add a sibling function `decryptWithPersonalPolicy(bytes)` that calls `seal_approve_cf_history` instead of `seal_approve_roster_reader`. Keep both wrappers so the existing mutual-decrypt flow is untouched.
+
+- [ ] **Step 3: Build**
+
+Run: `bun run build 2>&1 | tail -5`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/client/cf-history-seal.ts src/client/suiami-seal.ts
+git commit -m "client: Seal encrypt/decrypt helpers for cf-history personal policy"
+```
+
+---
+
+### Task 8: Wire into `request-suiami` handler
+
+**Files:**
+- Modify: `src/ski.ts` (the `ski:request-suiami` event handler)
+
+- [ ] **Step 1: Locate the handler**
+
+Run: `grep -n "ski:request-suiami\|maybeAppendRoster" src/ski.ts | head -10`
+
+- [ ] **Step 2: Add CF-chunk build + append call**
+
+Inside the handler, after `maybeAppendRoster` is added to `tx` and before the pre-build/sign step:
+
+```typescript
+try {
+  const { getCrossChainStatus } = await loadIka();
+  const ccs = await getCrossChainStatus(ws.address);
+  const tailBlobId = ''; // TODO: read from roster on-chain if we have it; empty for first write
+  const { maybeBuildCfChunk } = await import('./client/cf-history');
+  const cfBlobId = await maybeBuildCfChunk(ws.address, tailBlobId);
+  if (cfBlobId) {
+    tx.moveCall({
+      target: `${SUIAMI_PACKAGE_ID}::roster::append_cf_history`,
+      arguments: [
+        tx.object(ROSTER_SHARED_OBJECT_ID),
+        tx.pure.string(cfBlobId),
+        tx.object('0x6'),
+      ],
+    });
+  }
+} catch (cfErr) {
+  console.warn('[cf-history] skipped:', cfErr);
+}
+```
+
+Replace `SUIAMI_PACKAGE_ID` and `ROSTER_SHARED_OBJECT_ID` with the constants already imported in this file (check the existing `maybeAppendRoster` call for their exact names).
+
+- [ ] **Step 3: Tail-blob lookup — read roster for current `cf_history` tail**
+
+Add a helper that reads the record via GraphQL/gRPC and extracts the last `cf_history` entry. If the file already has `readRosterByAddress`, extend that to return `cfHistory: string[]` too, then:
+
+```typescript
+const tailBlobId = ccs.cfHistoryTail ?? '';
+```
+
+If extending `readRosterByAddress` is out of scope for this task, leave `tailBlobId = ''` (first-write-only path) and file a TODO to refine after Task 10.
+
+- [ ] **Step 4: Build + deploy + smoke-test**
+
+```bash
+bun run build && npx wrangler deploy
+```
+
+Then exercise the `ski:request-suiami` flow in the browser and confirm console shows `[cf-history]` messages and a new `append_cf_history` call in the tx effects.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ski.ts
+git commit -m "ski: wire cf-history into request-suiami PTB"
+```
+
+---
+
+### Task 9: Wire into `buildFullSuiamiWriteTx`
+
+**Files:**
+- Modify: `src/suins.ts` (the `buildFullSuiamiWriteTx` export)
+
+- [ ] **Step 1: Extend the `opts` type**
+
+Add to the existing `opts:` destructure/type:
+
+```typescript
+cfBlobId?: string; // optional: blob ID of a freshly-written CF chunk to append
+```
+
+- [ ] **Step 2: Append call inside the function**
+
+After the existing `set_identity` moveCall and before `tx.build`:
+
+```typescript
+if (opts.cfBlobId) {
+  tx.moveCall({
+    target: `${SUIAMI_PACKAGE_ID}::roster::append_cf_history`,
+    arguments: [
+      tx.object(ROSTER_SHARED_OBJECT_ID),
+      tx.pure.string(opts.cfBlobId),
+      tx.object('0x6'),
+    ],
+  });
+}
+```
+
+Use the same package-id constant the existing roster calls use in this file.
+
+- [ ] **Step 3: Update callers to pass `cfBlobId`**
+
+Find the `upgradeSuiami` callsite in `src/ski.ts` and the other caller(s):
+
+Run: `grep -rn "buildFullSuiamiWriteTx" src/ | head -10`
+
+Before each call, add:
+
+```typescript
+const { maybeBuildCfChunk } = await import('./client/cf-history');
+const cfBlobId = (await maybeBuildCfChunk(ws.address, '')) ?? undefined;
+// then in the existing opts: cfBlobId,
+```
+
+- [ ] **Step 4: Build**
+
+Run: `bun run build 2>&1 | tail -5`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/suins.ts src/ski.ts
+git commit -m "suins: buildFullSuiamiWriteTx accepts cfBlobId; upgradeSuiami wires it"
+```
+
+---
+
+### Task 10: `cfHistory()` console helper
+
+**Files:**
+- Modify: `src/ski.ts` (add a global helper, next to `suiamiAudit` and `who`)
+
+- [ ] **Step 1: Add the helper near the `who` helper**
+
+```typescript
+const _cfHistory = async () => {
+  try {
+    const ws = getWalletState();
+    if (!ws?.address) { console.error('[cfHistory] no wallet'); return; }
+    const { readRosterByAddress } = await import('./suins');
+    const record = await readRosterByAddress(ws.address);
+    if (!record) { console.log('[cfHistory] no SUIAMI record'); return; }
+    const blobIds = (record as unknown as { cf_history?: string[] }).cf_history ?? [];
+    if (blobIds.length === 0) { console.log('[cfHistory] empty'); return; }
+    const { WALRUS_AGGREGATOR } = await import('./client/cf-history');
+    const { decryptCfChunkBytes } = await import('./client/cf-history-seal');
+    for (const id of blobIds) {
+      const res = await fetch(`${WALRUS_AGGREGATOR}/v1/blobs/${id}`);
+      if (!res.ok) { console.log('[cfHistory]', id, 'walrus fetch failed'); continue; }
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      const chunk = await decryptCfChunkBytes(bytes);
+      if (!chunk) { console.log('[cfHistory]', id, 'decrypt failed'); continue; }
+      const d = chunk.data;
+      console.log(`[cfHistory] ${new Date(d.attestedAt).toISOString()} ${d.country}/${d.colo} ASN${d.asn} TLS${d.tlsVersion} ${d.httpProtocol}${d.verifiedBot ? ' [bot]' : ''}`);
+    }
+  } catch (err) {
+    console.error('[cfHistory] failed:', err);
+  }
+};
+(window as unknown as { cfHistory: typeof _cfHistory }).cfHistory = _cfHistory;
+(globalThis as unknown as { cfHistory: typeof _cfHistory }).cfHistory = _cfHistory;
+console.log('[ski] cfHistory hook installed — call cfHistory() to inspect your CF timeline');
+```
+
+Ensure `readRosterByAddress` returns `cf_history` as a field; if not, extend its parser (the contract getter is `record_cf_history`). Update the GraphQL projection (or whatever parse path `readRosterByAddress` uses) to include the new field.
+
+- [ ] **Step 2: Build + deploy**
+
+```bash
+bun run build && npx wrangler deploy 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Manual smoke-test (human loop)**
+
+In the browser at sui.ski:
+1. Run `cfHistory()` — expect empty if no writes yet.
+2. Trigger a `ski:request-suiami` (mint/attest flow).
+3. Re-run `cfHistory()` — expect 1 timeline entry with today's country/colo.
+4. Refresh page, re-run `cfHistory()` — still 1 entry (change-detection skipped the second write).
+5. Toggle VPN to a different country, trigger another write, run `cfHistory()` — expect 2 entries.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ski.ts src/suins.ts
+git commit -m "ski: cfHistory() console helper + readRosterByAddress cf_history field"
+```
+
+---
+
+### Task 11: End-to-end verification
+
+**Files:**
+- None (all manual / smoke test)
+
+- [ ] **Step 1: Type check + full build**
+
+Run: `bun run build 2>&1 | tail -10`
+Expected: clean, bundle size within ~100 KB of pre-feature.
+
+- [ ] **Step 2: Contract sanity**
+
+Run: `sui client call --package <NEW_PACKAGE_ID> --module roster --function append_cf_history --args <ROSTER_ID> \"smoke-test-blob-id\" 0x6 --gas-budget 10000000 2>&1 | tail -10`
+Expected: succeeds for a wallet that has a roster record; fails with `ENotOwner` for one that doesn't.
+
+- [ ] **Step 3: Curl the worker endpoint from multiple networks**
+
+From two different networks (e.g. home + phone hotspot):
+```bash
+curl -s https://sui.ski/api/cf-context | jq '.data | {country, asn, colo}'
+```
+Confirm `asn` and `colo` differ across networks.
+
+- [ ] **Step 4: Deploy**
+
+```bash
+bun run build && npx wrangler deploy 2>&1 | tail -5
+```
+
+- [ ] **Step 5: Tag**
+
+```bash
+git tag -a cf-enrichment-v1 -m "CF edge enrichment for SUIAMI — per-chunk Seal+Walrus"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage check:
+- Fields captured (spec §Fields): Task 5 writes all 9. ✓
+- Storage model (spec §Storage): Tasks 1–3 add Move struct/entries/policy; Tasks 6–7 client storage. ✓
+- Write path steps 1–4 (spec): Task 5 step 1, Tasks 6–7 steps 2–3, Tasks 8–9 step 4. ✓
+- Read path (spec): Task 10. ✓
+- Rollout items 1–5 (spec): Tasks 4, 5, 8–9, 11, 11 respectively. ✓
+- Out-of-scope items are NOT in any task. ✓
+
+Type consistency:
+- `CfFields` identical in `src/server/cf-context.ts` and `src/client/cf-history.ts`. ✓
+- `CfChunk.schema` pinned to `1` in both encrypt + decrypt paths. ✓
+- `append_cf_history(roster, blob_id, clock, ctx)` signature matches Tasks 2 / 8 / 9 / 11. ✓

--- a/docs/superpowers/specs/2026-04-16-cf-edge-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-16-cf-edge-enrichment-design.md
@@ -1,0 +1,173 @@
+# CF Edge Enrichment for SUIAMI — Design
+
+**Date:** 2026-04-16
+**Status:** Approved, ready for implementation plan
+**Related:** docs/suiami-identity.mdx (Cloudflare Integration section)
+
+## Goal
+
+Attach Cloudflare edge metadata to every SUIAMI squid-blob-bearing write, stored as a user-owned history only the wallet itself can decrypt today (and delegated agents can decrypt tomorrow). Pure data-collection for v1 — no consumer gates on this data yet.
+
+## Fields captured
+
+Nine fields per attestation, worker-sourced, HMAC-signed:
+
+| Field | Source | Notes |
+|---|---|---|
+| `country` | `cf-ipcountry` | 2-letter code |
+| `asn` | `request.cf.asn` | integer |
+| `threatScore` | `request.cf.threatScore` | 0-100, noisy on free tier |
+| `ipHash` | SHA-256(salt ‖ IP) | worker-held salt, not rotated in v1 |
+| `colo` | `request.cf.colo` | CF datacenter (e.g. "SJC") |
+| `verifiedBot` | `request.cf.verifiedBot` | boolean |
+| `tlsVersion` | `request.cf.tlsVersion` | e.g. "TLSv1.3" |
+| `httpProtocol` | `request.cf.httpProtocol` | e.g. "HTTP/3" |
+| `attestedAt` | server `Date.now()` | ms timestamp |
+
+## Storage: per-chunk Seal-sealed Walrus (personal policy)
+
+Each attestation is a single Walrus blob, Seal-encrypted under a new personal policy. Chosen over a rolling DO ring buffer or shared mutual-decrypt blob because it's IKA-native, zero-custody, and matches the encrypt.sui/alpha privacy brief from day one.
+
+### Move contract changes
+
+Two new functions on `contracts/suiami/sources/seal_roster.move` and `roster.move`:
+
+```move
+// seal_roster.move — new personal policy
+entry fun seal_approve_cf_history(
+  id: vector<u8>,
+  record: &IdentityRecord,
+  ctx: &TxContext,
+) {
+  assert!(tx_context::sender(ctx) == record.sui_address, ENotOwner);
+  assert!(vector::length(&record.cf_history) > 0, ENoHistory);
+  // Seal prefix check (id starts with record address bytes) as in existing policy
+}
+
+// roster.move — extend IdentityRecord + append entry
+struct IdentityRecord has store {
+  // ...existing fields
+  cf_history: vector<String>, // Walrus blob IDs, append-only
+}
+
+public entry fun append_cf_history(
+  record: &mut IdentityRecord,
+  blob_id: String,
+  ctx: &TxContext,
+) {
+  assert!(tx_context::sender(ctx) == record.sui_address, ENotOwner);
+  vector::push_back(&mut record.cf_history, blob_id);
+}
+```
+
+Existing records migrate with an empty vector — no data migration needed.
+
+### Walrus chunk payload (before Seal encryption)
+
+```
+{
+  "schema": 1,
+  "data": {country, asn, threatScore, ipHash, colo,
+           verifiedBot, tlsVersion, httpProtocol, attestedAt},
+  "sig":  "<worker-HMAC-SHA256 over canonical(data)>"
+}
+```
+
+HMAC is for tamper-evidence against a client that might swap values. Future consumers can verify the worker signed these values came from our edge.
+
+## Write path
+
+1. Client is about to build `request-suiami` or `buildFullSuiamiWriteTx`.
+2. Client fetches `GET /api/cf-context` → `{data, sig}` from worker.
+3. **Change detection:** if the user has prior chunks, decrypt only the tail chunk. Compare all fields except `attestedAt` — if identical, **skip the CF write entirely** (honors the "CF context rarely changes" reality; typical user ends up with 1-3 lifetime chunks).
+4. Otherwise: Seal-encrypt the chunk under `seal_approve_cf_history`, upload to Walrus, call `append_cf_history(record, new_blob_id)` in the same PTB as the existing roster write. One signature covers both.
+
+## Read path
+
+V1: client-only, via a new `cfHistory()` console helper that decrypts all chunks and prints a sparse timeline. No server-side consumer yet. Future consumers (Chronicom, Sibyl) will need a delegate policy — see Extensions.
+
+## Security & privacy
+
+- Personal policy (`seal_approve_cf_history`) — only the wallet's own `sui_address` can decrypt. Not mutual-decrypt like the squid blob.
+- Worker HMAC is tamper-evidence, not secrecy. Data is user-known; the goal is to let future consumers verify provenance.
+- `ipHash` uses a fixed worker-held salt in v1. Rotation is deferred — rotating the salt invalidates comparability across chunks.
+- No PII leaves the worker unencrypted to third parties. CF fields stay entirely inside Seal+Walrus.
+
+## Rollout
+
+1. Contract upgrade — adds one field + two entries. Policy is compatible upgrade (no breaking changes).
+2. Worker — new `src/server/cf-context.ts`, wired into `src/server/index.ts` router at `/api/cf-context`. `CF_HMAC_SECRET` + `CF_IP_SALT` env vars.
+3. Client — new `src/client/cf-history.ts`, called from `src/ski.ts` (`request-suiami` handler) and wrapped into `src/suins.ts` `buildFullSuiamiWriteTx`.
+4. Tests — HMAC roundtrip unit test; manual test that change-detection skips a no-change write.
+5. Deploy via `bun run build && npx wrangler deploy`.
+
+## Out of scope for v1
+
+- Delegated-agent decrypt policy — deferred until the first consumer actually needs it.
+- Salt rotation.
+- Aggregate analytics / cohort stats.
+- UI surfaces beyond the console helper.
+- ZK range/set proofs.
+
+---
+
+## Extensions — interesting directions
+
+These are not in v1 scope but worth tracking. Several lean heavily on the Cloudflare Developer Platform, which is the natural second wind for this feature once the on-chain substrate exists.
+
+### 1. Merkle chain-of-custody across chunks
+
+Each new chunk includes `prev_hash: sha256(prev_chunk_bytes)`. History becomes tamper-evident against *us* too — if the worker ever rewrote a chunk, the next chunk's hash wouldn't match the chain tip. Cost: 32 bytes per chunk. Pairs naturally with a user-signature field below.
+
+### 2. Dual signatures (worker HMAC + user Sui sig)
+
+Chunk carries both the edge HMAC and a user-side signature over the same canonicalized bytes. Proves both "this came from our edge at time T" AND "the wallet was in control at time T". Closes the gap where a stolen session cookie could mint a bogus chunk.
+
+### 3. Delegated-decrypt policy for agents
+
+Parallel Move function `seal_approve_cf_delegate(id, record, agent_cap, ctx)` that authorizes decrypt when the caller holds an `AgentDelegationCap` the user minted. Unlocks Chronicom/Sibyl reads without weakening the personal policy for everyone else. Natural consumer-activation story.
+
+### 4. ZK range / set proofs (Thunderbun fit)
+
+Prove "country ∈ allowed_set" or "asn is in residential list" without revealing the raw value. Groth16 on Sui is already a Thunderbun primitive. Unlocks compliance gating (OFAC check, regional eligibility) with zero PII leakage.
+
+### 5. Cloudflare Analytics Engine — anonymized aggregates
+
+Write **only hashed cohort bins** (e.g. `country_bin`, `asn_residential_bool`, `colo`) to CF Analytics Engine on every attestation. $0.25/M writes, 90-day retention, no per-user fingerprinting. Chronicom reads aggregates for "% of SUIAMI members on residential ASNs" etc. without decrypting anyone. Perfect for public stats pages without touching per-user storage. Would live at `docs/suiami-identity.mdx`-rendered endpoint.
+
+### 6. Cloudflare Vectorize — cohort discovery
+
+Embed each CF fingerprint as a vector (nine normalized fields → 16-dim vector), store in Vectorize with the wallet address as metadata. Client can query "who has a similar fingerprint to me?" with LSH buckets. Privacy: only members who've opted in get indexed; decryption still requires the personal Seal policy. Enables encrypt.sui/superteam.sui crowd-matching ("people with your CF signature tend to be on Brave + TLSv1.3").
+
+### 7. Cloudflare Workers AI — bot-pattern classifier at edge
+
+Run a small classifier (e.g. `@cf/huggingface/distilbert-sst-2` or a custom LoRA) over the CF fingerprint + User-Agent to output `{is_automated: bool, confidence: float}` server-side, signed by the worker, bundled into the chunk. Better signal than raw `threatScore`, stays private via the personal policy. Unlocks a high-quality Chronicom input without us writing heuristics.
+
+### 8. Cloudflare Turnstile — invisible challenge on high-value writes
+
+For squid-blob writes the user considers sensitive (mint, upgrade, cross-crowd Rumble), issue a Turnstile challenge from the cf-context endpoint. Pass/fail bit lands in the chunk as `turnstile: "pass" | "fail" | "skipped"`. Differentiates human-in-the-loop writes from scripted ones without user friction.
+
+### 9. Cloudflare KV — cached signed context
+
+Cache `{data, sig}` in CF KV keyed by `ipHash` with 60s TTL. Cuts HMAC-compute and CF-request-object reads by ~99% under hot traffic. Writes to KV from the worker; reads are sub-ms at edge. Irrelevant at our volume today, free speedup at scale.
+
+### 10. Cloudflare Workers Logpush — compliance archive to R2
+
+Stream the CF-context envelopes (data-only, never plaintext SUIAMI content) to R2 via Workers Logpush. 10-year retention for audit/compliance at R2 pricing. Useful if iUSD or any regulated crowd ever needs "we have edge attestations for every identity write."
+
+### 11. Cloudflare Browser Rendering — audit snapshots
+
+On high-value writes (agent provisioning, large cross-chain routing), Browser Rendering captures a timestamped screenshot of the user's confirmation UI. Seal-encrypted under personal policy, blob-id bundled into the CF chunk. Gives a user-private audit trail a lawyer would recognize.
+
+### 12. D1 — public aggregate dashboard
+
+A D1 database fed by Analytics Engine rollups, powering a public `sui.ski/stats` page: "SUIAMI: 1,248 verified identities across 43 countries, 89% residential ASNs, 67% Brave/Chrome, median TLS 1.3." Zero per-user data, all derived from anonymized bins. Marketing surface that proves the decentralized identity graph is real and growing.
+
+---
+
+## Decision log
+
+- **Option B (per-chunk Seal-sealed Walrus) chosen by 4/5-agent vote** over ring buffer (A), rolling blob rewrite (C), IndexedDB-local (D), hot+cold hybrid (E). Rationale: IKA-native, zero-custody, clean forward path to delegated-decrypt without migrating storage.
+- **Change-detection client-side** added to the write path after user flagged CF context rarely changes. Ensures the chunk count stays in the 1-3 range for typical users.
+- **No consumer gates on CF data in v1.** Matches earlier decision to ship enrichment as pure data-collection.
+- **Worker HMAC, not server-side Seal.** Seal is the user's encryption; worker signature is provenance. Keeping them orthogonal lets the user rotate Seal sessions without invalidating past HMAC-signed data.

--- a/public/styles.css
+++ b/public/styles.css
@@ -1888,6 +1888,23 @@ body {
 .wk-thunder-bubble-sender:hover {
   text-decoration-color: rgba(255, 184, 0, 0.7);
 }
+/* SUIAMI verified tick — rendered hidden by default; the post-render
+ * enrichment un-hides it when the roster lookup confirms the sender's
+ * entry has non-empty dwallet_caps (verified == true on-chain). */
+.wk-thunder-bubble-verified {
+  display: inline-block;
+  margin-left: 4px;
+  padding: 0 4px;
+  border-radius: 4px;
+  font-size: 0.7em;
+  font-weight: 900;
+  line-height: 1.3;
+  color: #0a0a0f;
+  background: #4ade80;
+  vertical-align: baseline;
+  cursor: help;
+}
+.wk-thunder-bubble-verified[hidden] { display: none; }
 .wk-thunder-mention {
   color: #93c5fd;
   cursor: pointer;
@@ -2963,6 +2980,56 @@ body {
 .ski-idle-audio-toggle--on:hover {
   background: rgba(34, 197, 94, 0.45);
   border-color: rgba(34, 197, 94, 0.7);
+}
+.ski-idle-session-clock {
+  all: unset;
+  position: absolute;
+  top: 6px;
+  left: 34px;
+  z-index: 6;
+  height: 22px;
+  min-width: 54px;
+  padding: 0 8px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.03em;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.ski-idle-session-clock:hover {
+  background: rgba(0, 0, 0, 0.75);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #fff;
+}
+.ski-idle-session-clock--busy {
+  cursor: wait;
+  opacity: 0.65;
+}
+.ski-idle-session-clock[hidden] { display: none !important; }
+.ski-idle-session-clock--warn {
+  color: #facc15;
+  border-color: rgba(250, 204, 21, 0.4);
+}
+.ski-idle-session-clock--crit {
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.5);
+  animation: ski-idle-session-clock-pulse 1s ease-in-out infinite;
+}
+@keyframes ski-idle-session-clock-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
 }
 .ski-idle-iusd-btn {
   all: unset;
@@ -5940,6 +6007,17 @@ a.ski-idle-bubble-name:hover {
   text-align: right;
   letter-spacing: 0.02em;
   transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+.app-toast-mint-check {
+  display: inline-block;
+  font-size: 1.1em;
+  animation: ski-mint-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes ski-mint-pulse {
+  0%, 100% { color: #22c55e; text-shadow: 0 0 6px rgba(34,197,94,.5); }
+  50%      { color: #4da2ff; text-shadow: 0 0 6px rgba(77,162,255,.5); }
 }
 
 /* ─── Wallet Connect Modal ─────────────────────────────────────────── */

--- a/src/client/ika.ts
+++ b/src/client/ika.ts
@@ -274,6 +274,10 @@ export interface CrossChainStatus {
   ika: boolean;
   dwalletCount: number;
   dwalletId: string;
+  /** Object IDs of every DWalletCap the wallet currently owns. Populated
+   *  for the SUIAMI Roster's `dwallet_caps: vector<address>` field —
+   *  non-empty caps flip `IdentityRecord.verified` to true on-chain. */
+  dwalletCaps: string[];
   btcAddress: string;
   ethAddress: string;
   solAddress: string;
@@ -664,6 +668,7 @@ export async function getCrossChainStatus(address: string): Promise<CrossChainSt
   let solAddress = '';
   let addresses: Array<{ chain: string; name: string; address: string }> = [];
   let dwalletId = '';
+  const dwalletCaps: string[] = [];
   let hasDWallet = false;
   let dwalletCount = 0;
 
@@ -687,6 +692,11 @@ export async function getCrossChainStatus(address: string): Promise<CrossChainSt
       if (!cap) continue;
       const capDwalletId = cap.content?.fields?.dwallet_id ?? '';
       if (!capDwalletId) continue;
+
+      // Collect the DWalletCap object ID for the roster's `dwallet_caps`
+      // vector — Move stores object IDs as addresses.
+      const capObjectId = cap.objectId ?? cap.content?.fields?.id?.id ?? '';
+      if (capObjectId) dwalletCaps.push(capObjectId);
 
       // Use first cap's dwalletId as the primary
       if (!dwalletId) dwalletId = capDwalletId;
@@ -744,6 +754,7 @@ export async function getCrossChainStatus(address: string): Promise<CrossChainSt
     ika: hasDWallet,
     dwalletCount,
     dwalletId,
+    dwalletCaps,
     btcAddress,
     ethAddress,
     solAddress,

--- a/src/client/thunder-stack.ts
+++ b/src/client/thunder-stack.ts
@@ -464,6 +464,29 @@ export async function warmThunderSession(opts?: { address?: string }): Promise<v
   }
 }
 
+/**
+ * Force-mint a fresh Seal session key — prompts the wallet immediately.
+ * Clears the cached key + in-memory promise first so the mint path runs
+ * end-to-end. Returns true on success, false on cancellation or failure.
+ *
+ * Used by the idle-overlay ski clock: clicking the countdown chip calls
+ * this so the user can re-sign before the current key ages out, without
+ * having to open a storm first. The clock auto-detects the new expiry
+ * via its localStorage poll once _loadOrMintSessionKey writes the key.
+ */
+export async function refreshSealSession(): Promise<boolean> {
+  if (!_warmer || !_address) return false;
+  try { localStorage.removeItem(SK_STORAGE_KEY(_address)); } catch {}
+  _sessionKeyPromise = null;
+  clearSealRejection(); // fresh click = intentional retry, clear cooldown
+  try {
+    await _warmer();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function resetThunderClient() {
   if (_client) {
     try { _client.messaging.disconnect(); } catch {}

--- a/src/server/agents/treasury-agents.ts
+++ b/src/server/agents/treasury-agents.ts
@@ -7831,8 +7831,11 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
     const buyerAddr = normalizeSuiAddress(buyer);
     const transport = new SuiGraphQLClient({ url: GQL_URL, network: 'mainnet' });
 
-    const price = BigInt(priceMist);
-    // Tradeport commission is deducted from seller — buyer pays just the price
+    const listingPriceMist = BigInt(priceMist);
+    // Tradeport charges the buyer a 3% fee on top of the listing price
+    // (Store.fee_bps = 300). Split-only-listing-price aborts the buy with
+    // code 4 (EInsufficientPayment).
+    const price = (listingPriceMist * 10300n) / 10000n;
     const totalNeeded = price;
 
     const TRADEPORT_V1_PKG = '0xff2251ea99230ed1cbe3a347a209352711c6723fcdcd9286e16636e65bb55cab';
@@ -7862,8 +7865,12 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
     const DB_SUI_USDC_ISV = 389750322;
     const DB_DEEP_TYPE = '0xdeeb7a4662eec9f2f3def03fb937a663dddaa2e215b8078a284d026b7946c270::deep::DEEP';
 
-    // Resolve on-chain Listing ID (Store keys by Listing ID, not NFT ID)
-    let buyId = nftTokenId;
+    // Resolve the listing object AND its Tradeport version.
+    // V1 `buy_listing_without_transfer_policy` keys the store by NFT ID,
+    // V2 `listings::buy` keys by Listing object ID. Using the wrong key aborts
+    // in `dynamic_field::borrow_child_object` (code 1, EFieldDoesNotExist).
+    let listingObjectId: string | null = null;
+    let isV2 = false;
     try {
       const gqlRes = await fetch(GQL_URL, {
         method: 'POST',
@@ -7874,8 +7881,21 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
       });
       type R = { data?: { object?: { owner?: { address?: { asObject?: { owner?: { address?: { address?: string } } } } } } } };
       const gqlJson = await gqlRes.json() as R;
-      buyId = gqlJson?.data?.object?.owner?.address?.asObject?.owner?.address?.address ?? nftTokenId;
+      listingObjectId = gqlJson?.data?.object?.owner?.address?.asObject?.owner?.address?.address ?? null;
     } catch {}
+    if (listingObjectId) {
+      try {
+        const typeRes = await fetch('https://sui-rpc.publicnode.com', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'sui_getObject', params: [listingObjectId, { showType: true }] }),
+        });
+        const typeJson = await typeRes.json() as { result?: { data?: { type?: string } } };
+        const t = typeJson?.result?.data?.type ?? '';
+        if (t.startsWith(TRADEPORT_V2_PKG)) isV2 = true;
+      } catch {}
+    }
+    const buyId = isV2 ? (listingObjectId ?? nftTokenId) : nftTokenId;
 
     const tx = new Transaction();
     tx.setSender(buyerAddr);
@@ -7895,23 +7915,12 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
     // (otherwise a pre-funded buyer would buy with "free" SUI
     // and leave the cache out-of-pocket).
     if (availSui >= totalNeeded && route !== 'iusd-redeem') {
-      // Simple: split from gas, buy — try v1 then v2
-      for (const v2 of [false, true]) {
-        try {
-          const t = new Transaction();
-          t.setSender(buyerAddr);
-          const payment = t.splitCoins(t.gas, [t.pure.u64(totalNeeded.toString())]);
-          addTradeportBuy(t, buyId, payment, v2);
-          const txBytes = await t.build({ client: transport as never });
-          return { txBase64: uint8ToBase64(txBytes), description: `Buy via SUI direct (${Number(totalNeeded) / 1e9} SUI)` };
-        } catch (err) {
-          if (!v2 && String(err).includes('MoveAbort')) {
-            console.warn('[Tradeport] v1 failed, retrying v2:', err instanceof Error ? err.message : err);
-            continue;
-          }
-          throw err;
-        }
-      }
+      const t = new Transaction();
+      t.setSender(buyerAddr);
+      const payment = t.splitCoins(t.gas, [t.pure.u64(totalNeeded.toString())]);
+      addTradeportBuy(t, buyId, payment, isV2);
+      const txBytes = await t.build({ client: transport as never });
+      return { txBase64: uint8ToBase64(txBytes), description: `Buy via SUI direct (${Number(totalNeeded) / 1e9} SUI)` };
     }
 
     if (route === 'usdc-swap' || route === 'iusd-redeem') {
@@ -8016,9 +8025,7 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
             return { error: `Need ~${usdNeeded.toFixed(2)} iUSD (have ${(Number(realIusdBal)/1e9).toFixed(2)})` };
           }
 
-          let lastErr: unknown = null;
-          for (const v2 of [false, true]) {
-            try {
+          try {
               const swapTx = new Transaction();
               swapTx.setSender(buyerAddr);
               // Merge all iUSD coins into primary, split the swap amount
@@ -8060,19 +8067,15 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
               swapTx.transferObjects([iusdChange, deepChangeA, usdcChange, deepChangeB], swapTx.pure.address(buyerAddr));
               // 4) Split payment from gas + buy
               const payment = swapTx.splitCoins(swapTx.gas, [swapTx.pure.u64(totalNeeded.toString())]);
-              addTradeportBuy(swapTx, buyId, payment, v2);
+              addTradeportBuy(swapTx, buyId, payment, isV2);
               const txBytes = await swapTx.build({ client: transport as never });
               return {
                 txBase64: uint8ToBase64(txBytes),
-                description: `Direct swap ${(Number(iusdToSwapMist) / 1e9).toFixed(2)} iUSD → SUI + buy ${Number(totalNeeded) / 1e9} SUI listing via Tradeport ${v2 ? 'v2' : 'v1'} (no cache prefund)`,
+                description: `Direct swap ${(Number(iusdToSwapMist) / 1e9).toFixed(2)} iUSD → SUI + buy ${Number(totalNeeded) / 1e9} SUI listing via Tradeport ${isV2 ? 'v2' : 'v1'} (no cache prefund)`,
               };
             } catch (err) {
-              lastErr = err;
-              if (v2 || !String(err).includes('MoveAbort')) break;
-              console.warn('[Tradeport-direct-swap] v1 failed, retrying v2:', err instanceof Error ? err.message : err);
+              return { error: `Direct swap build failed: ${err instanceof Error ? err.message : String(err)}` };
             }
-          }
-          return { error: `Direct swap build failed: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}` };
         }
 
         // Step 2: Build user TX — send iUSD (+ USDC top-up when
@@ -8123,14 +8126,9 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
           ? `${Number(iusdCapped) / 1e9} iUSD + ${Number(usdcTopUpMist) / 1e6} USDC`
           : `${Number(iusdCapped) / 1e9} iUSD`;
 
-        // Build iUSD+USDC payment + Tradeport buy. Listing/store
-        // layouts differ between v1 and v2 and we can't tell
-        // which one from the listing row alone — try v1 first,
-        // fall back to v2 on MoveAbort. A fresh Transaction per
-        // attempt avoids mutating the same handle twice.
-        let lastErr: unknown = null;
-        for (const v2 of [false, true]) {
-          try {
+        // Build iUSD+USDC payment + Tradeport buy. Version is resolved
+        // above from the listing object type — no v1/v2 retry needed.
+        try {
             const userTx = new Transaction();
             userTx.setSender(buyerAddr);
 
@@ -8161,20 +8159,16 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
             }
 
             const payment = userTx.splitCoins(userTx.gas, [userTx.pure.u64(totalNeeded.toString())]);
-            addTradeportBuy(userTx, buyId, payment, v2);
+            addTradeportBuy(userTx, buyId, payment, isV2);
 
             const txBytes = await userTx.build({ client: transport as never });
             return {
               txBase64: uint8ToBase64(txBytes),
-              description: `Send ${payLabel} to cache + buy ${Number(price) / 1e9} SUI listing via Tradeport ${v2 ? 'v2' : 'v1'} (pre-funded by ultron: ${prefundDigest})`,
+              description: `Send ${payLabel} to cache + buy ${Number(price) / 1e9} SUI listing via Tradeport ${isV2 ? 'v2' : 'v1'} (pre-funded by ultron: ${prefundDigest})`,
             };
           } catch (err) {
-            lastErr = err;
-            if (v2 || !String(err).includes('MoveAbort')) break;
-            console.warn('[Tradeport-iusd] v1 failed, retrying v2:', err instanceof Error ? err.message : err);
+            return { error: `Tradeport build failed: ${err instanceof Error ? err.message : String(err)}` };
           }
-        }
-        return { error: `Tradeport build failed: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}` };
       }
 
       if (usdcCoins.length === 0 || realUsdcBal === 0n) {
@@ -8212,7 +8206,7 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
 
       // Now purchase with gas (has original SUI + swapped SUI)
       const payment = tx.splitCoins(tx.gas, [tx.pure.u64(totalNeeded.toString())]);
-      addTradeportBuy(tx, buyId, payment);
+      addTradeportBuy(tx, buyId, payment, isV2);
 
       const txBytes = await tx.build({ client: transport as never });
       return { txBase64: uint8ToBase64(txBytes), description: `USDC→SUI swap + Tradeport buy (${Number(swapAmount) / 1e6} USDC → ${Number(shortfall) / 1e9} SUI)` };

--- a/src/ski.ts
+++ b/src/ski.ts
@@ -470,15 +470,20 @@ window.addEventListener('ski:request-suiami', async (e) => {
       const { Transaction } = await import('@mysten/sui/transactions');
       const { normalizeSuiAddress } = await import('@mysten/sui/utils');
       const tx = new Transaction();
-      // Tx sender MUST be set explicitly. WaaP and other wallets that
-      // pre-build with their own SDK fail with "Failed to build
-      // transaction: Missing transaction sender" when sender is unset
-      // even though signAndExecuteTransaction will eventually attach
-      // the signing account. Always normalize for WaaP addresses that
-      // may not be zero-padded.
       tx.setSender(normalizeSuiAddress(ws.address));
-      maybeAppendRoster(tx, ws.address, name, undefined, blobId, sealNonce);
-      const { digest } = await signAndExecuteTransaction(tx);
+      // Attach dwallet caps so the roster entry flips verified:true
+      // when the user has already rumbled. If not, caps array is empty
+      // and the entry stays unverified — same behavior as before.
+      let dwalletCaps: string[] = [];
+      try {
+        const { getCrossChainStatus } = await loadIka();
+        dwalletCaps = (await getCrossChainStatus(ws.address)).dwalletCaps ?? [];
+      } catch {}
+      maybeAppendRoster(tx, ws.address, name, undefined, blobId, sealNonce, dwalletCaps);
+      // Pre-build to bytes so WaaP's v1 SDK doesn't crash reading
+      // gasConfig.price (v2 uses gasData, v1 reads gasConfig).
+      const rosterBytes = await tx.build({ client: grpcClient as never });
+      const { digest } = await signAndExecuteTransaction(rosterBytes);
       console.log('[suiami] roster attestation written:', digest);
       showToast(`\u2713 SUIAMI on-chain for ${name}.sui`);
     } catch (rosterErr) {
@@ -761,6 +766,60 @@ const _suiamiAudit = async () => {
 (globalThis as unknown as { suiamiAudit: typeof _suiamiAudit }).suiamiAudit = _suiamiAudit;
 console.log('[ski] suiamiAudit hook installed — call suiamiAudit() to check current roster state');
 
+// ── who(key) — SUIAMI reverse lookup by chain:address ──
+//
+// SUIAMI is the pronoun — `who` is the question. Given any chain-keyed
+// address, return the Roster entry that owns it. Uses the
+// `lookup_by_chain` dynamic field the contract maintains as a third
+// index alongside name_hash and address.
+//
+// Accepts:
+//   who("0xa84c…")       → bare 64-hex address
+//   who("eth:0xd8…")     → Ethereum
+//   who("btc:bc1q…")     → Bitcoin
+//   who("sol:5Kz…")      → Solana
+//
+// Caveat: non-native chains are only reverse-resolvable when the owner
+// opted to write the address plaintext on-chain. The default Roster
+// write keeps BTC/ETH/SOL Seal-encrypted in the Walrus blob and does
+// not index them here — a deliberate privacy choice. `who` will miss
+// those entries and that's expected.
+const _who = async (input: string) => {
+  if (!input || typeof input !== 'string') {
+    console.error('[who] usage: who("<chain>:<address>") or who("<bare-0x-address>")');
+    return { error: 'bad-input' };
+  }
+  let key = input.trim();
+  // Bare 0x-prefixed 64-hex address → auto-wrap
+  if (!key.includes(':') && /^0x[0-9a-f]{64}$/i.test(key)) key = `sui:${key.toLowerCase()}`;
+  if (!key.includes(':')) {
+    console.error('[who] key must be "<chain>:<address>" (chain ∈ sui/eth/btc/sol/…)');
+    return { error: 'bad-format' };
+  }
+  try {
+    const { readRosterByChain } = await import('./suins.js');
+    const record = await readRosterByChain(key);
+    if (!record) {
+      console.log(`[who] no SUIAMI entry for ${key}`);
+      return { ok: false, key };
+    }
+    console.log(`[who] ${key} →`);
+    console.log(`  name:            ${record.name}`);
+    console.log(`  address:         ${record.sui_address}`);
+    console.log(`  verified:        ${record.verified}`);
+    console.log(`  dwallet_caps:    ${record.dwallet_caps.length}`);
+    console.log(`  chains on-chain: ${Object.keys(record.chains).join(', ') || '(none)'}`);
+    console.log(`  walrus_blob_id:  ${record.walrus_blob_id || '(none)'}`);
+    return { ok: true, key, record };
+  } catch (err) {
+    console.error('[who] query failed:', err);
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+};
+(window as unknown as { who: typeof _who }).who = _who;
+(globalThis as unknown as { who: typeof _who }).who = _who;
+console.log('[ski] who hook installed — call who("<chain>:<address>") or who("<bare-0x-addr>") for reverse roster lookup');
+
 // ── Bronzong — Seal-gated SUIAMI upgrade (#157) ──
 //
 // Retroactive SUIAMI upgrade using Seal threshold encryption instead
@@ -846,6 +905,21 @@ const _upgradeSuiami = async (extraNames: string[] = []) => {
       console.warn(`[upgradeSuiami] no NFT id found for: ${missingNftIds.join(', ')} — writing roster entries without setTargetAddress`);
     }
 
+    // Gather DWalletCap object IDs so Roster's `verified` flips to true
+    // on-chain for this batch of names. Non-fatal if the wallet hasn't
+    // rumbled yet — caps array is just empty and verified stays false.
+    let dwalletCaps: string[] = [];
+    try {
+      const { getCrossChainStatus } = await loadIka();
+      const ccs = await getCrossChainStatus(ws.address);
+      dwalletCaps = ccs.dwalletCaps ?? [];
+      if (dwalletCaps.length) {
+        console.log(`[upgradeSuiami] attaching ${dwalletCaps.length} dwallet cap(s) — roster will mark verified:true`);
+      }
+    } catch (ccsErr) {
+      console.warn('[upgradeSuiami] getCrossChainStatus failed, writing unverified entries:', ccsErr);
+    }
+
     showToast(`\u{1F300} Writing SUIAMI for ${names.length} name${names.length > 1 ? 's' : ''}\u2026`);
     const bytes = await buildFullSuiamiWriteTx({
       sender: ws.address,
@@ -856,6 +930,7 @@ const _upgradeSuiami = async (extraNames: string[] = []) => {
       // but semantically it's a Seal id, not an AES IV.
       sealNonce: Array.from(sealId),
       setTargetForNfts: true,
+      dwalletCaps,
     });
     const { digest } = await signAndExecuteTransaction(bytes);
     const summary = `\u2713 SUIAMI upgraded \u2014 ${names.length} name${names.length > 1 ? 's' : ''} Seal-gated on the roster policy`;

--- a/src/suins.ts
+++ b/src/suins.ts
@@ -109,6 +109,7 @@ export function maybeAppendRoster(
   crossChain?: { btc?: string; eth?: string; sol?: string },
   walrusBlobId?: string,
   sealNonce?: number[],
+  dwalletCaps?: string[],
 ): boolean {
   // Roster is a mainnet-only Move package — silently skip on testnet hosts
   // so testnet PTBs don't reference nonexistent package IDs.
@@ -121,9 +122,14 @@ export function maybeAppendRoster(
   // Only SUI address goes on-chain; cross-chain addresses live in the Walrus blob
   const chains: [string, string][] = [['sui', addr]];
 
-  // Skip if unchanged since last write
+  // Caps drive the on-chain `verified` flag (non-empty → true). The debounce
+  // below keys on both the chain list AND the caps so a cap-population
+  // write isn't suppressed just because the chain list is unchanged.
+  const caps = (dwalletCaps ?? []).filter(c => typeof c === 'string' && c.startsWith('0x'));
+
+  // Skip if unchanged since last write (address list + cap list together)
   const rosterKey = `ski:roster:${addr}`;
-  const currentRoster = JSON.stringify(chains);
+  const currentRoster = JSON.stringify({ chains, caps });
   try { if (localStorage.getItem(rosterKey) === currentRoster) return false; } catch {}
 
   // keccak256(bare_name_bytes) — same hash as Thunder nameHash
@@ -140,7 +146,7 @@ export function maybeAppendRoster(
       tx.pure.vector('u8', nh),
       tx.pure.vector('string', chains.map(c => c[0])),
       tx.pure.vector('string', chains.map(c => c[1])),
-      tx.pure.vector('address', []), // dwallet_caps — TODO: populate from IKA state
+      tx.pure.vector('address', caps),
       tx.pure.string(walrusBlobId || ''),
       tx.pure.vector('u8', sealNonce || []),
       tx.object('0x6'),
@@ -162,7 +168,13 @@ export async function readRoster(name: string): Promise<Record<string, string> |
   if (!isMainnet()) return null;
   const bare = name.replace(/\.sui$/i, '').toLowerCase();
   const nh = keccak_256(new TextEncoder().encode(bare));
-  const nhB64 = btoa(String.fromCharCode(...nh));
+  // GraphQL `dynamicField(name: { type: "vector<u8>", bcs: … })` expects
+  // the BCS-encoded vector<u8> — ULEB128 length prefix + raw bytes. The
+  // hash is 32 bytes so the prefix fits in one byte (0x20).
+  const prefixed = new Uint8Array(nh.length + 1);
+  prefixed[0] = nh.length;
+  prefixed.set(nh, 1);
+  const nhB64 = btoa(String.fromCharCode(...prefixed));
   try {
     const res = await fetch('https://graphql.mainnet.sui.io/graphql', {
       method: 'POST',
@@ -226,6 +238,62 @@ export async function readRosterByAddress(address: string): Promise<RosterRecord
       for (const { key, value } of record.chains.contents) {
         chains[key] = value;
       }
+    }
+    return {
+      name: record.name ?? '',
+      sui_address: record.sui_address ?? '',
+      chains,
+      walrus_blob_id: record.walrus_blob_id ?? '',
+      seal_nonce: record.seal_nonce ?? [],
+      verified: record.verified ?? false,
+      dwallet_caps: record.dwallet_caps ?? [],
+      updated_ms: record.updated_ms ?? '0',
+    };
+  } catch { return null; }
+}
+
+/**
+ * Reverse-lookup the SUIAMI Roster by a chain:address key.
+ *
+ * Key format matches the Move contract's third index: `"<chain>:<addr>"`
+ * — e.g. `"sui:0xa84c…"`, `"btc:bc1q…"`, `"eth:0x…"`. The Sui-chain key
+ * works for every roster entry today because the default `set_identity`
+ * call always writes the sender's Sui address under the `sui` key. Other
+ * chains are only reverse-resolvable if the owner opted to write them
+ * plaintext on-chain (BTC/ETH/SOL normally live Seal-encrypted in the
+ * Walrus blob and are *not* indexed here).
+ *
+ * Returns the full IdentityRecord, or null if the key isn't registered.
+ */
+export async function readRosterByChain(chainKey: string): Promise<RosterRecord | null> {
+  if (!isMainnet()) return null;
+  const key = (chainKey || '').trim();
+  if (!key.includes(':')) return null;
+  // GraphQL dynamic_field(name: { type: "0x1::string::String", bcs: <utf-8 len-prefixed> })
+  // needs ULEB128 length prefix + raw UTF-8 bytes, BCS-encoded.
+  const utf8 = new TextEncoder().encode(key);
+  const lenPrefix: number[] = [];
+  let n = utf8.length;
+  while (n >= 0x80) { lenPrefix.push((n & 0x7f) | 0x80); n >>>= 7; }
+  lenPrefix.push(n & 0x7f);
+  const bcs = new Uint8Array(lenPrefix.length + utf8.length);
+  bcs.set(lenPrefix, 0);
+  bcs.set(utf8, lenPrefix.length);
+  const b64 = btoa(String.fromCharCode(...bcs));
+  try {
+    const res = await fetch(GQL_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        query: `{ object(address: "${ROSTER_OBJ}") { dynamicField(name: { type: "0x1::string::String", bcs: "${b64}" }) { value { ... on MoveValue { json } } } } }`,
+      }),
+    });
+    const gql = await res.json() as any;
+    const record = gql?.data?.object?.dynamicField?.value?.json;
+    if (!record) return null;
+    const chains: Record<string, string> = {};
+    if (record.chains?.contents) {
+      for (const { key: ck, value } of record.chains.contents) chains[ck] = value;
     }
     return {
       name: record.name ?? '',
@@ -871,6 +939,7 @@ export async function buildSetDefaultNsTx(rawAddress: string, domain: string): P
     ],
   });
   maybeAppendRoster(tx);
+  appendWaapDeterministicEcdsaJitter(tx, walletAddress);
   const bytes = await tx.build({ client: transport as never });
   return { bytes, tx };
 }
@@ -2257,6 +2326,9 @@ export async function buildPostTradeConfigureTx(opts: {
   walrusBlobId?: string;    // reuse existing encrypted squid blob if available
   sealNonce?: number[];     // matching nonce for the blob
   writeRoster?: boolean;    // default true; set false to skip roster entry
+  /** DWalletCap object IDs owned by the buyer. Flips the roster
+   *  `verified` flag to true when non-empty. */
+  dwalletCaps?: string[];
 }): Promise<Uint8Array & { tx?: InstanceType<typeof Transaction> }> {
   const walletAddress = normalizeSuiAddress(opts.sender);
   const bareName = opts.domain.replace(/\.sui$/i, '').toLowerCase();
@@ -2286,6 +2358,7 @@ export async function buildPostTradeConfigureTx(opts: {
   const shouldWriteRoster = opts.writeRoster !== false && isMainnet();
   if (shouldWriteRoster) {
     const nameHash = Array.from(keccak_256(new TextEncoder().encode(bareName)));
+    const caps = (opts.dwalletCaps ?? []).filter(c => typeof c === 'string' && c.startsWith('0x'));
     tx.moveCall({
       package: ROSTER_PKG,
       module: 'roster',
@@ -2298,10 +2371,7 @@ export async function buildPostTradeConfigureTx(opts: {
         // BTC / ETH / SOL are in the Walrus blob, not here.
         tx.pure.vector('string', ['sui']),
         tx.pure.vector('string', [walletAddress]),
-        // dwallet_caps — empty for now; IKA cap ownership is intentionally
-        // not exposed in this entry so the squid dWallets aren't linkable
-        // to the name on-chain.
-        tx.pure.vector('address', []),
+        tx.pure.vector('address', caps),
         tx.pure.string(opts.walrusBlobId ?? ''),
         tx.pure.vector('u8', opts.sealNonce ?? []),
         tx.object('0x6'),
@@ -2313,6 +2383,7 @@ export async function buildPostTradeConfigureTx(opts: {
   // may already have a primary they want to keep (e.g. superteam.sui).
   // Making great.sui the new default is an explicit, separate action.
 
+  appendWaapDeterministicEcdsaJitter(tx, walletAddress);
   const bytes = await buildWithTx(tx, transport);
   const out = bytes as Uint8Array & { tx?: InstanceType<typeof Transaction> };
   out.tx = tx;
@@ -2372,6 +2443,12 @@ export async function buildFullSuiamiWriteTx(opts: {
   entries: Array<{ domain: string; nftId?: string }>;
   walrusBlobId: string;
   sealNonce: number[];
+  /** DWalletCap object IDs owned by the sender. Non-empty flips the
+   *  roster's `verified` flag to true on-chain, which is what every
+   *  verified-tier gate (Chronicom, decrypt-as-a-service, agent
+   *  provisioning) reads from. Passed as `vector<address>` — Move
+   *  treats object IDs as addresses. */
+  dwalletCaps?: string[];
   /** If true and `nftId` is provided on an entry, chains a
    *  `setTargetAddress` call to repoint that name at the sender. */
   setTargetForNfts?: boolean;
@@ -2386,6 +2463,8 @@ export async function buildFullSuiamiWriteTx(opts: {
   const tx = new Transaction();
   tx.setSender(walletAddress);
   const suinsTx = new SuinsTransaction(suinsClient, tx);
+
+  const caps = (opts.dwalletCaps ?? []).filter(c => typeof c === 'string' && c.startsWith('0x'));
 
   for (const entry of opts.entries) {
     const bareName = entry.domain.replace(/\.sui$/i, '').toLowerCase();
@@ -2410,7 +2489,7 @@ export async function buildFullSuiamiWriteTx(opts: {
         tx.pure.vector('u8', nameHash),
         tx.pure.vector('string', ['sui']),
         tx.pure.vector('string', [walletAddress]),
-        tx.pure.vector('address', []),
+        tx.pure.vector('address', caps),
         tx.pure.string(opts.walrusBlobId),
         tx.pure.vector('u8', opts.sealNonce),
         tx.object('0x6'),

--- a/src/suins.ts
+++ b/src/suins.ts
@@ -55,6 +55,34 @@ async function buildWithTx(tx: InstanceType<typeof Transaction>, client: unknown
   return bytes;
 }
 
+/**
+ * WaaP signs with deterministic ECDSA (Silence Labs MPC, RFC-6979 secp256k1).
+ * Same input bytes always produce the same signature, so when we hit the 1/256
+ * case where r or s loses its leading zero (63-byte raw sig → Sui rejects with
+ * "Invalid signature length: expected 64 bytes, got 63"), retrying the same tx
+ * is hopeless — the signature is deterministic and the tx will fail forever.
+ *
+ * Fix: append a real Move op to the PTB whose argument varies per build, so
+ * each attempt produces fresh tx bytes → fresh signature → ~255/256 odds of
+ * dodging the short-sig case per click. Splitting a tiny amount of MIST off
+ * gas and transferring it back to the sender does the job: it survives v1↔v2
+ * BCS round-trips (because it lives in the command list, not gasData), and
+ * the dust comes right back so cost is just the gas for the extra commands.
+ *
+ * Only meaningful for WaaP wallets, but harmless on every other wallet — we
+ * apply it unconditionally so we don't have to know the wallet at build time.
+ */
+function appendWaapDeterministicEcdsaJitter(
+  tx: InstanceType<typeof Transaction>,
+  senderAddress: string,
+): void {
+  // 1..1024 MIST — well below any meaningful threshold but > 256 (the size of
+  // the rejection space we need to step out of).
+  const dustAmount = 1n + BigInt(Math.floor(Math.random() * 1024));
+  const [dust] = tx.splitCoins(tx.gas, [tx.pure.u64(dustAmount)]);
+  tx.transferObjects([dust], tx.pure.address(senderAddress));
+}
+
 // ─── iUSD Treasury Fee ─────────────────────────────────────────────────
 
 /** iUSD treasury address — receives protocol fees. Developed as t2000.sui.
@@ -1708,9 +1736,19 @@ export async function buildKioskPurchaseTx(
  * tradeport_listings::buy_listing_without_transfer_policy which transfers
  * the NFT directly to the buyer.
  */
-// Two Tradeport deployments — listings created under either package
+// Tradeport deployments:
+//   V1 (0xff22…) — original regular listings. Upgraded in-place to 0xc99c…
+//     which adds the OB (order-book) variant. OB listings live in both the
+//     original listings Store AND the orderbook Store at 0x3af0… and must
+//     be bought via `buy_ob_listing_without_transfer_policy` (not the
+//     regular buy). The non-OB buy aborts with code 4 on OB listings.
+//   V2 (0xb42d…) — newer listings contract with `listings::buy`.
 const TRADEPORT_V1_PKG = '0xff2251ea99230ed1cbe3a347a209352711c6723fcdcd9286e16636e65bb55cab';
 const TRADEPORT_V1_STORE = '0xf96f9363ac5a64c058bf7140723226804d74c0dab2dd27516fb441a180cd763b';
+const TRADEPORT_V1_STORE_ISV = 670935706;
+const TRADEPORT_OB_PKG = '0xc99caf110751c3c615c64a27c81bf5c829e39b21a32613b9e4f87ca69cb8ec38';
+const TRADEPORT_OB_STORE = '0x3af0a94360253c80fbabe73f6832be0a49ddfc0b8772ccd5335f568cbc356da1';
+const TRADEPORT_OB_STORE_ISV = 766744204;
 const TRADEPORT_V2_PKG = '0xb42dbb7413b79394e1a0175af6ae22b69a5c7cc5df259cd78072b6818217c027';
 const TRADEPORT_V2_STORE = '0x47cba0b6309a12ce39f9306e28b899ed4b3698bce4f4911fd0c58ff2329a2ff6';
 // Keep old aliases for existing code
@@ -1722,6 +1760,7 @@ const TRADEPORT_STORE = TRADEPORT_V1_STORE;
  * Chain: NFT → dynamic_field wrapper → SimpleListing
  */
 export async function resolveTradeportListingId(nftTokenId: string): Promise<string | null> {
+  // Primary: GraphQL owner-chain traversal (NFT → wrapper → SimpleListing)
   try {
     const res = await fetch(GQL_URL, {
       method: 'POST',
@@ -1732,9 +1771,73 @@ export async function resolveTradeportListingId(nftTokenId: string): Promise<str
     });
     type R = { data?: { object?: { owner?: { address?: { address?: string; asObject?: { owner?: { address?: { address?: string } } } } } } } };
     const json = await res.json() as R;
-    // grandparent = SimpleListing object ID
-    return json?.data?.object?.owner?.address?.asObject?.owner?.address?.address ?? null;
+    const gqlResult = json?.data?.object?.owner?.address?.asObject?.owner?.address?.address ?? null;
+    if (gqlResult) return gqlResult;
+  } catch { /* fall through to JSON-RPC backup */ }
+
+  // Backup: JSON-RPC two-hop owner traversal when GraphQL schema drifts.
+  // NFT owned by dynamic_field wrapper, wrapper owned by SimpleListing.
+  try {
+    const getOwner = async (objectId: string): Promise<string | null> => {
+      const res = await fetch('https://sui-rpc.publicnode.com', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'sui_getObject', params: [objectId, { showOwner: true }] }),
+      });
+      const json = await res.json() as { result?: { data?: { owner?: Record<string, string> } } };
+      return json?.result?.data?.owner?.ObjectOwner ?? null;
+    };
+    const wrapperId = await getOwner(nftTokenId);
+    if (!wrapperId) return null;
+    return await getOwner(wrapperId);
   } catch { return null; }
+}
+
+/**
+ * Resolve the Tradeport listing AND which buy flavor applies.
+ *
+ * Three flavors, three different move calls:
+ *   - `v1`   — `buy_listing_without_transfer_policy(store, nft_id, coin)`
+ *   - `v1ob` — `buy_ob_listing_without_transfer_policy(store, ob_store, nft_id, coin)`
+ *              OB (order-book) listings live in both the listings Store AND the
+ *              orderbook Store; the regular buy aborts on them with code 4.
+ *   - `v2`   — `listings::buy(store, listing_id, coin)` — V2 store is keyed by
+ *              Listing object ID, not NFT ID.
+ */
+export async function resolveTradeportListing(
+  nftTokenId: string,
+): Promise<{ id: string; kind: 'v1' | 'v1ob' | 'v2' } | null> {
+  const id = await resolveTradeportListingId(nftTokenId);
+  if (!id) return null;
+  // Probe the listing object's type to differentiate V1 vs V2
+  let type = '';
+  try {
+    const res = await fetch('https://sui-rpc.publicnode.com', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'sui_getObject', params: [id, { showType: true }] }),
+    });
+    const json = await res.json() as { result?: { data?: { type?: string } } };
+    type = json?.result?.data?.type ?? '';
+  } catch { return null; }
+  if (type.startsWith(TRADEPORT_V2_PKG)) return { id, kind: 'v2' };
+  if (!type.startsWith(TRADEPORT_V1_PKG)) return null;
+
+  // V1 listing. Check the orderbook Store for a dynamic field keyed by the
+  // SimpleListing ID — its presence means this is an OB listing.
+  try {
+    const bcs = btoa(String.fromCharCode(...new Uint8Array(id.slice(2).match(/.{2}/g)!.map((h) => parseInt(h, 16)))));
+    const res = await fetch(GQL_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        query: `{ object(address: "${TRADEPORT_OB_STORE}") { dynamicField(name: { type: "0x2::object::ID", bcs: "${bcs}" }) { value { ... on MoveValue { type { repr } } } } } }`,
+      }),
+    });
+    const json = await res.json() as { data?: { object?: { dynamicField?: unknown | null } } };
+    if (json?.data?.object?.dynamicField) return { id, kind: 'v1ob' };
+  } catch { /* fall through — treat as regular v1 */ }
+  return { id, kind: 'v1' };
 }
 
 export async function buildTradeportPurchaseTx(
@@ -1743,55 +1846,93 @@ export async function buildTradeportPurchaseTx(
   priceMist: string,
   /** If provided, setTargetAddress + setDefault in the same PTB */
   domainName?: string,
+  /** On-chain listing object ID from Tradeport API — skips on-chain resolution if provided */
+  knownListingId?: string,
 ): Promise<Uint8Array> {
   const walletAddress = normalizeSuiAddress(rawAddress);
   const transport = gqlClient;
 
-  const price = BigInt(priceMist);
-  const fee = price * 300n / 10000n;
+  // Tradeport charges the buyer a 3% fee on top of the listing price.
+  const listingPrice = BigInt(priceMist);
+  const price = (listingPrice * 10300n) / 10000n;
 
-  // Resolve the on-chain Listing object ID (Store keys by Listing ID, not NFT ID)
-  const listingId = await resolveTradeportListingId(nftTokenId);
-  const buyId = listingId ?? nftTokenId; // fallback to nftTokenId for v1 legacy
+  // Resolve listing + kind deterministically. knownListingId may be a UUID
+  // from Tradeport's API — those aren't on-chain object IDs and must be ignored.
+  const validKnown = knownListingId?.startsWith('0x') ? knownListingId : null;
+  const resolved = await resolveTradeportListing(nftTokenId);
+  if (!resolved && !validKnown) {
+    throw new Error('Tradeport listing not found on-chain for this NFT');
+  }
+  const kind = resolved?.kind ?? 'v1';
 
-  // Race v1 and v2 — first successful build wins (avoids slow dry-run timeout)
-  const versions = [
-    { pkg: TRADEPORT_V1_PKG, store: TRADEPORT_V1_STORE, fn: 'tradeport_listings::buy_listing_without_transfer_policy' },
-    { pkg: TRADEPORT_V2_PKG, store: TRADEPORT_V2_STORE, fn: 'listings::buy' },
-  ];
+  const tx = new Transaction();
+  tx.setSender(walletAddress);
+  const payment = tx.splitCoins(tx.gas, [tx.pure.u64(price.toString())]);
+  const buyResult = addTradeportBuyCall(tx, kind, resolved?.id ?? validKnown!, nftTokenId, payment);
+  tx.moveCall({ target: '0x2::coin::destroy_zero', typeArguments: [SUI_TYPE], arguments: [payment] });
 
-  const attempts = versions.map(async (v) => {
-    const tx = new Transaction();
-    tx.setSender(walletAddress);
-    // Tradeport buy expects EXACTLY the listing price — commission is deducted from seller's portion
-    const payment = tx.splitCoins(tx.gas, [tx.pure.u64(price.toString())]);
-    const nft = tx.moveCall({
-      target: `${v.pkg}::${v.fn}`,
-      typeArguments: [SUINS_REG_TYPE],
-      arguments: [
-        tx.sharedObjectRef({ objectId: v.store, initialSharedVersion: 3377344, mutable: true }),
-        tx.pure.id(buyId),
-        payment,
-      ],
-    });
-    // buy consumes the entire coin — destroy the zero remainder
-    tx.moveCall({ target: '0x2::coin::destroy_zero', typeArguments: [SUI_TYPE], arguments: [payment] });
-    // Set target address + default in the same PTB (single sign)
+  // Only the regular V1 buy returns an NFT handle usable for in-PTB record
+  // setup; OB and V2 auto-transfer the NFT inside the Move call.
+  if (kind === 'v1') {
     if (domainName) {
       const suinsClient = new SuinsClient({ client: transport as never, network: getSuinsNetwork() });
       const suinsTx = new SuinsTransaction(suinsClient, tx);
-      suinsTx.setTargetAddress({ nft, address: walletAddress });
+      suinsTx.setTargetAddress({ nft: buyResult!, address: walletAddress });
       suinsTx.setDefault(domainName.endsWith('.sui') ? domainName : `${domainName}.sui`);
     }
-    tx.transferObjects([nft], tx.pure.address(walletAddress));
-    return buildWithTx(tx, transport);
-  });
-
-  try {
-    return await Promise.any(attempts);
-  } catch (agg) {
-    throw new Error(`Tradeport purchase failed on both v1 and v2: ${agg}`);
+    tx.transferObjects([buyResult!], tx.pure.address(walletAddress));
   }
+
+  return buildWithTx(tx, transport);
+}
+
+/**
+ * Emit the correct Tradeport buy call for the listing's kind and return the
+ * move-call result (the NFT handle for v1; an empty result for v1ob/v2 since
+ * those variants auto-transfer the NFT inside Move).
+ */
+function addTradeportBuyCall(
+  tx: InstanceType<typeof Transaction>,
+  kind: 'v1' | 'v1ob' | 'v2',
+  listingId: string,
+  nftTokenId: string,
+  payment: ReturnType<InstanceType<typeof Transaction>['splitCoins']>,
+): ReturnType<InstanceType<typeof Transaction>['moveCall']> | null {
+  if (kind === 'v2') {
+    tx.moveCall({
+      target: `${TRADEPORT_V2_PKG}::listings::buy`,
+      typeArguments: [SUINS_REG_TYPE],
+      arguments: [
+        tx.sharedObjectRef({ objectId: TRADEPORT_V2_STORE, initialSharedVersion: 3377344, mutable: true }),
+        tx.pure.id(listingId),
+        payment,
+      ],
+    });
+    return null;
+  }
+  if (kind === 'v1ob') {
+    tx.moveCall({
+      target: `${TRADEPORT_OB_PKG}::tradeport_listings::buy_ob_listing_without_transfer_policy`,
+      typeArguments: [SUINS_REG_TYPE],
+      arguments: [
+        tx.sharedObjectRef({ objectId: TRADEPORT_V1_STORE, initialSharedVersion: TRADEPORT_V1_STORE_ISV, mutable: true }),
+        tx.sharedObjectRef({ objectId: TRADEPORT_OB_STORE, initialSharedVersion: TRADEPORT_OB_STORE_ISV, mutable: true }),
+        tx.pure.id(nftTokenId),
+        payment,
+      ],
+    });
+    return null;
+  }
+  // v1 regular
+  return tx.moveCall({
+    target: `${TRADEPORT_V1_PKG}::tradeport_listings::buy_listing_without_transfer_policy`,
+    typeArguments: [SUINS_REG_TYPE],
+    arguments: [
+      tx.sharedObjectRef({ objectId: TRADEPORT_V1_STORE, initialSharedVersion: TRADEPORT_V1_STORE_ISV, mutable: true }),
+      tx.pure.id(nftTokenId),
+      payment,
+    ],
+  });
 }
 
 /**
@@ -1802,13 +1943,12 @@ export async function buildTradeportPurchaseTx(
 export async function buildSwapAndPurchaseTx(
   rawAddress: string,
   purchase: { type: 'kiosk'; kioskId: string; nftId: string; priceMist: string }
-    | { type: 'tradeport'; nftTokenId: string; priceMist: string },
+    | { type: 'tradeport'; nftTokenId: string; priceMist: string; listingId?: string },
   selectedCoinType: string | null,  // coin type of selected balance (null = SUI)
   selectedBalance: number,          // USD value of selected coin (hint for estimates)
   outputCoinType: string | null,    // coin type of output selector (null = SUI)
   suiPrice: number,                 // current SUI price in USD
   selectedTokenPrice?: number,      // price per token of selected coin (e.g. XAUM price)
-  _tradeportV2?: boolean,           // internal: retry with Tradeport v2 on v1 MoveAbort
 ): Promise<Uint8Array> {
   const walletAddress = normalizeSuiAddress(rawAddress);
   const transport = gqlClient;
@@ -1816,8 +1956,14 @@ export async function buildSwapAndPurchaseTx(
   tx.setSender(walletAddress);
 
   const SLIPPAGE_BPS = 200n; // 2% slippage tolerance
-  const priceMist = BigInt(purchase.priceMist);
-  // Tradeport commission is deducted from seller — buyer pays just the price
+  // Tradeport charges the buyer a 3% fee on top of the listing price
+  // (verified on-chain: Store.fee_bps = 300 and BuySimpleListingEvent.price
+  // < actual paid amount by ~3%). Splitting only the listing price aborts
+  // with code 4 (EInsufficientPayment).
+  const listingPrice = BigInt(purchase.priceMist);
+  const priceMist = purchase.type === 'tradeport'
+    ? (listingPrice * 10300n) / 10000n
+    : listingPrice;
   const totalSuiNeeded = priceMist;
 
   // Helper: calculate min output with slippage protection
@@ -1962,38 +2108,20 @@ export async function buildSwapAndPurchaseTx(
     });
     tx.transferObjects([nft], tx.pure.address(walletAddress));
   } else {
-    // Resolve on-chain Listing ID (Store keys by Listing ID, not NFT ID)
-    const listingId = await resolveTradeportListingId(purchase.nftTokenId);
-    const buyId = listingId ?? purchase.nftTokenId;
-    const price = BigInt(purchase.priceMist);
-    // Tradeport buy expects EXACTLY the listing price — commission deducted from seller
-    const payment = tx.splitCoins(tx.gas, [tx.pure.u64(price.toString())]);
-    const tpPkg = _tradeportV2 ? TRADEPORT_V2_PKG : TRADEPORT_V1_PKG;
-    const tpStore = _tradeportV2 ? TRADEPORT_V2_STORE : TRADEPORT_V1_STORE;
-    const tpFn = _tradeportV2 ? 'listings::buy' : 'tradeport_listings::buy_listing_without_transfer_policy';
-    tx.moveCall({
-      target: `${tpPkg}::${tpFn}`,
-      typeArguments: [SUINS_REG_TYPE],
-      arguments: [
-        tx.sharedObjectRef({ objectId: tpStore, initialSharedVersion: 3377344, mutable: true }),
-        tx.pure.id(buyId),
-        payment,
-      ],
-    });
+    const knownLid = 'listingId' in purchase && purchase.listingId?.startsWith('0x') ? purchase.listingId : null;
+    const resolved = await resolveTradeportListing(purchase.nftTokenId);
+    if (!resolved && !knownLid) {
+      throw new Error('Tradeport listing not found on-chain for this NFT');
+    }
+    const kind = resolved?.kind ?? 'v1';
+    // priceMist above already includes the 3% Tradeport buyer fee
+    const payment = tx.splitCoins(tx.gas, [tx.pure.u64(priceMist.toString())]);
+    addTradeportBuyCall(tx, kind, resolved?.id ?? knownLid!, purchase.nftTokenId, payment);
     // buy consumes entire coin — destroy zero remainder
     tx.moveCall({ target: '0x2::coin::destroy_zero', typeArguments: [SUI_TYPE], arguments: [payment] });
   }
 
-  try {
-    return await buildWithTx(tx, transport);
-  } catch (err) {
-    // Tradeport v1 listing not found — retry with v2
-    if (!_tradeportV2 && purchase.type === 'tradeport' && String(err).includes('MoveAbort')) {
-      console.warn('[Tradeport] v1 failed, retrying with v2:', err instanceof Error ? err.message : err);
-      return buildSwapAndPurchaseTx(rawAddress, purchase, selectedCoinType, selectedBalance, outputCoinType, suiPrice, selectedTokenPrice, true);
-    }
-    throw err;
-  }
+  return await buildWithTx(tx, transport);
 }
 
 // ─── Volcarodon PSM + Tradeport chain ────────────────────────────────
@@ -2015,7 +2143,6 @@ export async function buildIusdBurnAndPurchaseTx(
     | { type: 'tradeport'; nftTokenId: string; priceMist: string },
   suiPrice: number,
   iusdBurnMist: bigint,
-  _tradeportV2?: boolean,
 ): Promise<Uint8Array> {
   const walletAddress = normalizeSuiAddress(rawAddress);
   const transport = gqlClient;
@@ -2025,7 +2152,16 @@ export async function buildIusdBurnAndPurchaseTx(
   const USDC_TYPE = suinsCfg().coins.USDC.type;
   const SLIPPAGE_BPS = 200n;
   const withSlippage = (expected: bigint) => expected * (10000n - SLIPPAGE_BPS) / 10000n;
-  const priceMist = BigInt(purchase.priceMist);
+  // Tradeport (both regular and OB variants) charges the buyer a 3% fee on
+  // top of the listing price — verified against the on-chain Store (fee_bps
+  // = 300) and recent successful buy events. Splitting just `priceMist`
+  // aborts with code 4 (EInsufficientPayment). Kiosk listings handle their
+  // royalty via TransferPolicy inside the purchase call, so we only add the
+  // fee for Tradeport.
+  const listingPrice = BigInt(purchase.priceMist);
+  const priceMist = purchase.type === 'tradeport'
+    ? (listingPrice * 10300n) / 10000n
+    : listingPrice;
 
   // Fetch all the balances we need for routing.
   const [suiCoins, usdcCoins, iusdCoins] = await Promise.all([
@@ -2123,34 +2259,16 @@ export async function buildIusdBurnAndPurchaseTx(
     });
     tx.transferObjects([nft], tx.pure.address(walletAddress));
   } else {
-    const listingId = await resolveTradeportListingId(purchase.nftTokenId);
-    const buyId = listingId ?? purchase.nftTokenId;
-    const price = BigInt(purchase.priceMist);
-    const payment = tx.splitCoins(tx.gas, [tx.pure.u64(price.toString())]);
-    const tpPkg = _tradeportV2 ? TRADEPORT_V2_PKG : TRADEPORT_V1_PKG;
-    const tpStore = _tradeportV2 ? TRADEPORT_V2_STORE : TRADEPORT_V1_STORE;
-    const tpFn = _tradeportV2 ? 'listings::buy' : 'tradeport_listings::buy_listing_without_transfer_policy';
-    tx.moveCall({
-      target: `${tpPkg}::${tpFn}`,
-      typeArguments: [SUINS_REG_TYPE],
-      arguments: [
-        tx.sharedObjectRef({ objectId: tpStore, initialSharedVersion: 3377344, mutable: true }),
-        tx.pure.id(buyId),
-        payment,
-      ],
-    });
+    const resolved = await resolveTradeportListing(purchase.nftTokenId);
+    if (!resolved) {
+      throw new Error('Tradeport listing not found on-chain for this NFT');
+    }
+    const payment = tx.splitCoins(tx.gas, [tx.pure.u64(priceMist.toString())]);
+    addTradeportBuyCall(tx, resolved.kind, resolved.id, purchase.nftTokenId, payment);
     tx.moveCall({ target: '0x2::coin::destroy_zero', typeArguments: [SUI_TYPE], arguments: [payment] });
   }
 
-  try {
-    return await buildWithTx(tx, transport);
-  } catch (err) {
-    if (!_tradeportV2 && purchase.type === 'tradeport' && String(err).includes('MoveAbort')) {
-      console.warn('[Tradeport] v1 failed, retrying with v2:', err instanceof Error ? err.message : err);
-      return buildIusdBurnAndPurchaseTx(rawAddress, purchase, suiPrice, iusdBurnMist, true);
-    }
-    throw err;
-  }
+  return await buildWithTx(tx, transport);
 }
 
 // ─── Cold-start SUI → iUSD via DeepBook + Volcarodon PSM ────────────

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -360,15 +360,13 @@ function fmtStable(n: number): string {
 
 let toastSeq = 0;
 
-export function showToast(msg: string, isHtml = false) {
+export function showToast(msg: string, isHtml = false, persistent = false) {
   const text = msg.trim();
   if (!text) return;
-  // All toasts use copyable behavior: first click copies, second dismisses
   if (isHtml) {
-    // HTML toasts (rare) — still use copyable with raw text extraction
-    showCopyableToast(text, text.replace(/<[^>]*>/g, ''));
+    showCopyableToast(text, text.replace(/<[^>]*>/g, ''), 8000, persistent);
   } else {
-    showCopyableToast(text, text);
+    showCopyableToast(text, text, 8000, persistent);
   }
 }
 
@@ -415,7 +413,7 @@ function toggleAddrRow(el: HTMLElement, fullAddr: string, color: string) {
   }, ADDR_RESTORE_MS));
 }
 
-function showCopyableToast(display: string, fullText: string, durationMs = 8000) {
+function showCopyableToast(display: string, fullText: string, durationMs = 8000, persistent = false) {
   const text = display.trim();
   if (!text) return;
   let root = document.getElementById('app-toast-root');
@@ -438,6 +436,77 @@ function showCopyableToast(display: string, fullText: string, durationMs = 8000)
 
   const hint = document.createElement('div');
   hint.className = 'app-toast-copy-hint';
+  hint.textContent = persistent ? 'click to dismiss' : 'click to copy';
+  toast.appendChild(hint);
+
+  root.appendChild(toast);
+  requestAnimationFrame(() => document.getElementById(id)?.classList.add('show'));
+
+  let copied = false;
+  let removed = false;
+  const remove = () => {
+    if (removed) return;
+    removed = true;
+    toast.classList.remove('show');
+    setTimeout(() => toast.remove(), TOAST_ANIMATION_MS);
+  };
+  const _autoTimer = persistent ? null : setTimeout(remove, 4500);
+  toast.addEventListener('click', () => {
+    if (persistent && !copied) { copied = true; remove(); return; }
+    if (copied) { if (_autoTimer) clearTimeout(_autoTimer); remove(); return; }
+    copied = true;
+    navigator.clipboard.writeText(fullText).catch(() => {});
+    hint.textContent = '\u2713 Copied — click again to dismiss';
+    hint.style.color = '#4ade80';
+  });
+}
+
+const SUINS_REG_TYPE = '0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0::suins_registration::SuinsRegistration';
+
+function _extractNftId(effects: unknown): string {
+  if (!effects || typeof effects !== 'object') return '';
+  const eff = effects as Record<string, unknown>;
+  const created = (eff.created ?? eff.createdObjects ?? []) as Array<Record<string, unknown>>;
+  for (const obj of created) {
+    const ref = (obj.reference ?? obj) as Record<string, unknown>;
+    const id = (ref.objectId ?? ref.objectID ?? obj.objectId ?? '') as string;
+    const type = (obj.objectType ?? obj.type ?? ref.objectType ?? '') as string;
+    if (id && type.includes('SuinsRegistration')) return id;
+    if (id && !type) return id;
+  }
+  return '';
+}
+
+function showMintToast(name: string, digest: string, effects?: unknown) {
+  const bare = name.replace(/\.sui$/i, '');
+  const nftId = _extractNftId(effects);
+  const display = `<span class="app-toast-mint-check">\u2713</span> ${bare} SUIAMI proof generated`;
+  const full = [
+    `${bare}.sui minted`,
+    `Digest: ${digest || '(pending)'}`,
+    nftId ? `NFT: ${nftId}` : '',
+  ].filter(Boolean).join('\n');
+
+  let root = document.getElementById('app-toast-root');
+  if (!root) {
+    root = document.createElement('div');
+    root.id = 'app-toast-root';
+    root.className = 'app-toast-root';
+    document.body.appendChild(root);
+  }
+  const toast = document.createElement('div');
+  const id = 'app-toast-' + ++toastSeq;
+  toast.className = 'app-toast app-toast--copyable';
+  toast.id = id;
+  toast.setAttribute('role', 'status');
+
+  const msgEl = document.createElement('div');
+  msgEl.className = 'app-toast-copy-msg';
+  msgEl.innerHTML = display;
+  toast.appendChild(msgEl);
+
+  const hint = document.createElement('div');
+  hint.className = 'app-toast-copy-hint';
   hint.textContent = 'click to copy';
   toast.appendChild(hint);
 
@@ -452,16 +521,13 @@ function showCopyableToast(display: string, fullText: string, durationMs = 8000)
     toast.classList.remove('show');
     setTimeout(() => toast.remove(), TOAST_ANIMATION_MS);
   };
-  // Auto-dismiss after 4.5s regardless of interaction state. Click still
-  // copies; the copy state just sticks around until the timer fires or
-  // the user clicks again to dismiss early.
-  const _autoTimer = setTimeout(remove, 4500);
   toast.addEventListener('click', () => {
-    if (copied) { clearTimeout(_autoTimer); remove(); return; }
+    if (copied) { remove(); return; }
     copied = true;
-    navigator.clipboard.writeText(fullText).catch(() => {});
-    hint.textContent = '\u2713 Copied — click again to dismiss';
+    navigator.clipboard.writeText(full).catch(() => {});
+    hint.textContent = '\u2713 Copied — click to dismiss';
     hint.style.color = '#4ade80';
+    hint.style.opacity = '1';
   });
 }
 
@@ -3746,6 +3812,72 @@ function _toggleThunderConvo() {
   try { localStorage.setItem('ski:thunder-card-open', _thunderConvoOpen ? '1' : '0'); } catch {}
 }
 
+/** In-memory SUIAMI roster cache keyed by lowercased Sui address.
+ *  `null` means a verified lookup came back empty (no entry / network
+ *  blip) and we should retry after the TTL, rather than pummeling the
+ *  GraphQL endpoint every bubble. */
+const _suiamiAddrCache = new Map<string, { name: string; verified: boolean; expires: number }>();
+const SUIAMI_CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Enrich Thunder bubbles post-render: swap truncated addresses for
+ *  SUIAMI names and un-hide the verified tick when `verified: true`
+ *  comes back from the roster. Dedupes by address so N bubbles from
+ *  the same sender cost one lookup. Silent on failure — bubbles just
+ *  stay address-only, which matches pre-change behavior. */
+async function _enrichThunderBubblesWithSuiami(container: HTMLElement) {
+  const nodes = Array.from(
+    container.querySelectorAll<HTMLElement>('.wk-thunder-bubble-sender[data-sender-addr]'),
+  );
+  if (!nodes.length) return;
+  const byAddr = new Map<string, HTMLElement[]>();
+  for (const node of nodes) {
+    const addr = node.dataset.senderAddr?.toLowerCase();
+    if (!addr) continue;
+    const list = byAddr.get(addr) ?? [];
+    list.push(node);
+    byAddr.set(addr, list);
+  }
+  const now = Date.now();
+  const needLookup: string[] = [];
+  for (const addr of byAddr.keys()) {
+    const cached = _suiamiAddrCache.get(addr);
+    if (!cached || cached.expires < now) needLookup.push(addr);
+  }
+
+  if (needLookup.length > 0) {
+    const { readRosterByAddress } = await import('./suins.js');
+    await Promise.all(needLookup.map(async (addr) => {
+      try {
+        const record = await readRosterByAddress(addr);
+        _suiamiAddrCache.set(addr, {
+          name: record?.name ?? '',
+          verified: !!record?.verified,
+          expires: Date.now() + SUIAMI_CACHE_TTL_MS,
+        });
+      } catch {
+        _suiamiAddrCache.set(addr, { name: '', verified: false, expires: Date.now() + 30_000 });
+      }
+    }));
+  }
+
+  for (const [addr, elList] of byAddr) {
+    const entry = _suiamiAddrCache.get(addr);
+    if (!entry) continue;
+    for (const el of elList) {
+      const textEl = el.querySelector<HTMLElement>('.wk-thunder-bubble-sender-text');
+      const badge = el.querySelector<HTMLElement>('.wk-thunder-bubble-verified');
+      if (entry.name && textEl) {
+        textEl.textContent = entry.name;
+        el.dataset.sender = entry.name;
+      }
+      if (badge) {
+        if (entry.verified) badge.removeAttribute('hidden');
+        else badge.setAttribute('hidden', '');
+      }
+    }
+  }
+}
+
 /** Render the conversation view for a counterparty in the thunder received area. */
 async function _renderConversation(counterparty: string, force = false) {
   const bare = counterparty.replace(/\.sui$/, '').toLowerCase();
@@ -3775,10 +3907,19 @@ async function _renderConversation(counterparty: string, force = false) {
   const myAddr = ws.address?.toLowerCase() || '';
   const rows = doMessages.map(m => {
     const isOut = m.senderAddress.toLowerCase() === myAddr;
-    const sender = isOut ? '' : m.senderAddress.slice(0, 8);
+    const senderDisplay = isOut ? '' : m.senderAddress.slice(0, 8);
+    const senderAddrLc = m.senderAddress.toLowerCase();
     const cls = isOut ? 'wk-thunder-bubble--out' : 'wk-thunder-bubble--in';
     const selCls = _selectedThunderTs.has(m.createdAt) ? ' wk-thunder-bubble--selected' : '';
-    const label = isOut ? '' : (sender ? `<span class="wk-thunder-bubble-sender" data-sender="${esc(sender)}">${esc(sender)}</span> ` : '');
+    // Sender label carries the full address in data-sender-addr so the
+    // post-render SUIAMI resolver can find the bubble without having to
+    // re-query the DO. The visible text is the truncated preview; it
+    // gets overwritten with the SUIAMI name once the roster lookup
+    // lands. The verified tick is hidden until `verified: true` comes
+    // back from the chain.
+    const label = isOut ? '' : (senderDisplay
+      ? `<span class="wk-thunder-bubble-sender" data-sender="${esc(senderDisplay)}" data-sender-addr="${esc(senderAddrLc)}"><span class="wk-thunder-bubble-sender-text">${esc(senderDisplay)}</span><span class="wk-thunder-bubble-verified" hidden title="SUIAMI verified \u2014 dWallet-backed identity">\u2713</span></span> `
+      : '');
     // Render @mentions as clickable
     const msgHtml = esc(m.text).replace(/@([a-z0-9-]{3,63})(\.sui)?/gi, (_, name: string) => {
       const b = name.toLowerCase();
@@ -3792,6 +3933,12 @@ async function _renderConversation(counterparty: string, force = false) {
     : '';
 
   receivedEl.innerHTML = rows + deleteBtn;
+
+  // ── SUIAMI enrichment — resolve each unique sender's roster entry in
+  // the background and patch the rendered bubbles with SUIAMI name +
+  // verified mark. Runs deduped across a conversation so N bubbles
+  // from the same sender cost exactly one GraphQL roundtrip.
+  void _enrichThunderBubblesWithSuiami(receivedEl);
 
   // Show decrypt bar OR reply input — never both
   const unquestedEl = document.getElementById('wk-thunder-unquested');

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -4544,8 +4544,10 @@ async function fetchAndShowNsPrice(label: string) {
       if (nsTradeportListing) _cache.tp = nsTradeportListing;
       sessionStorage.setItem('ski:ns-resolve', JSON.stringify(_cache));
     } catch {}
-    // Save resolved label to localStorage (not on every keystroke — only after resolution)
-    try { if (nsPriceFetchFor) localStorage.setItem('ski:ns-label', nsPriceFetchFor); } catch {}
+    // Save resolved label to localStorage — but only if it still matches the
+    // current input. Prevents stale intermediate fetches (e.g. "crow") from
+    // clobbering the label the user actually typed (e.g. "crowd").
+    try { if (nsPriceFetchFor && nsPriceFetchFor === nsLabel) localStorage.setItem('ski:ns-label', nsPriceFetchFor); } catch {}
     if (sr) _maybeDiscoverRealOwner(sr);
     // Clear stale amount if name isn't actionable (no mint, no listing to buy)
     const actionable = nsAvail === 'available' || nsAvail === 'grace' || nsKioskListing || nsTradeportListing;
@@ -7351,7 +7353,7 @@ function renderSkiMenu() {
       // Build purchase descriptor
       const purchase = nsKioskListing
         ? { type: 'kiosk' as const, kioskId: nsKioskListing.kioskId, nftId: nsKioskListing.nftId, priceMist: nsKioskListing.priceMist }
-        : { type: 'tradeport' as const, nftTokenId: nsTradeportListing!.nftTokenId, priceMist: nsTradeportListing!.priceMist };
+        : { type: 'tradeport' as const, nftTokenId: nsTradeportListing!.nftTokenId, priceMist: nsTradeportListing!.priceMist, listingId: nsTradeportListing!.listingId };
 
       if (btn) btn.textContent = 'TRADE';
       const selTokenPrice = getTokenPrice(selectedCoinSymbol ?? '') ?? undefined;
@@ -9215,7 +9217,7 @@ function renderSkiMenu() {
         if (nsKioskListing) {
           purchaseTx = await buildKioskPurchaseTx(ws2.address, nsKioskListing.kioskId, nsKioskListing.nftId, nsKioskListing.priceMist, domain);
         } else {
-          purchaseTx = await buildTradeportPurchaseTx(ws2.address, nsTradeportListing!.nftTokenId, nsTradeportListing!.priceMist, domain);
+          purchaseTx = await buildTradeportPurchaseTx(ws2.address, nsTradeportListing!.nftTokenId, nsTradeportListing!.priceMist, domain, nsTradeportListing!.listingId);
         }
         if (btn) btn.textContent = '\u270f';
         const { digest } = await signAndExecuteTransaction(purchaseTx);
@@ -9305,7 +9307,7 @@ function renderSkiMenu() {
         try {
           const tx = await buildExecuteShadeOrderTx(ws2.address, existingOrder);
           if (btn) btn.textContent = '\u270f';
-          const { digest } = await signAndExecuteTransaction(tx);
+          const { digest, effects: shadeEff } = await signAndExecuteTransaction(tx);
           // Remove shade order — it's consumed
           removeShadeOrder(ws2.address, existingOrder.objectId);
           nsShadeOrder = null;
@@ -9326,7 +9328,7 @@ function renderSkiMenu() {
           _preRumbledNames.add(label.toLowerCase());
           try { localStorage.setItem('ski:pre-rumbled', JSON.stringify([..._preRumbledNames])); } catch {}
           window.dispatchEvent(new CustomEvent('ski:name-acquired', { detail: { name: label } }));
-          showToast(`${domain} registered \u2713 ${digest ? digest.slice(0, 8) + '\u2026' : ''}`);
+          showMintToast(domain, digest, shadeEff);
           if (ws2.address) try { localStorage.removeItem(`ski:balances:${ws2.address}`); } catch {}
           refreshPortfolio(true);
         } catch (err) {
@@ -9395,13 +9397,15 @@ function renderSkiMenu() {
       if (signingCancelled) throw new Error('cancelled');
       if (btn) btn.textContent = '\u270f';
       let digest: string;
+      let regEffects: unknown;
       if (result.sponsorAddress) {
-        // Sponsored tx: user signs, then get sponsor sig, then submit both
-        const { digest: d } = await signAndExecuteSponsoredTx(result.txBytes);
+        const { digest: d, effects: e } = await signAndExecuteSponsoredTx(result.txBytes);
         digest = d;
+        regEffects = e;
       } else {
-        const { digest: d } = await signAndExecuteTransaction(result.txBytes);
+        const { digest: d, effects: e } = await signAndExecuteTransaction(result.txBytes);
         digest = d;
+        regEffects = e;
       }
       if (signingCancelled) throw new Error('cancelled');
       // Update NS row: blue square status + show tx digest
@@ -9417,7 +9421,7 @@ function renderSkiMenu() {
       updateSkiDot('blue-square', app.suinsName);
       nsOwnedFetchedFor = ''; // force re-fetch of owned domains list
       _fetchOwnedDomains();
-      showToast(`${domain} registered ✓ ${digest ? digest.slice(0, 8) + '…' : ''}`);
+      showMintToast(domain, digest, regEffects);
       if (ws2.address) try { localStorage.removeItem(`ski:balances:${ws2.address}`); } catch {}
       refreshPortfolio(true);
     } catch (err) {
@@ -10866,7 +10870,7 @@ function bindEvents() {
           const _bal = Math.max(0, totalUsd);
           const _balLabel = _bal >= 1 ? Math.round(_bal).toLocaleString() : _bal.toFixed(2);
           const balHtml = `<span class="ski-idle-card-bal"><span class="ski-idle-card-bal-icon">$</span><span class="ski-idle-card-bal-whole">${_balLabel}</span></span> `;
-          const iusdBadge = _suiamiVerifyHtml ? ' <img src="/assets/iusd.svg" class="ski-idle-card-iusd" width="16" height="16" alt="iUSD">' : '';
+          const iusdBadge = _suiamiVerifyHtml ? ' <img src="/assets/iusd-256.png" class="ski-idle-card-iusd" width="16" height="16" alt="iUSD">' : '';
           const _atBtn = `<button class="ski-idle-card-at" id="ski-idle-thunder-at" type="button" title=""><svg width="22" height="22" viewBox="0 0 20 20"><rect x="2" y="2" width="16" height="16" rx="3" fill="#4da2ff" stroke="white" stroke-width="1.8"/></svg></button>`;
           const _recallBtn = `<button class="ski-idle-card-recall" id="ski-idle-recall-vaults" type="button" title="Recall all unclaimed vaults">\u21A9</button>`;
           card.innerHTML = `${_atBtn}<span class="ski-idle-card-name" title="Populate input">${esc(primaryName)}</span>${balHtml}${iusdBadge}${badgeHtml ? ` <span class="ski-idle-card-badges">${badgeHtml}</span>` : ''}${_recallBtn}`;
@@ -11074,7 +11078,13 @@ function bindEvents() {
           if (clearBtn) clearBtn.style.display = 'none';
         }
       });
-      _idleNsInput?.addEventListener('blur', _unfreezeGif);
+      _idleNsInput?.addEventListener('blur', () => {
+        _unfreezeGif();
+        const val = _idleNsInput!.value.trim().toLowerCase().replace(/\.sui$/, '');
+        if (val && val.length >= 3 && isValidNsLabel(val)) {
+          setTimeout(() => _updateIdleCard(val), 150);
+        }
+      });
 
       const _idleThunderInputEl = _idleOverlay.querySelector('#ski-idle-thunder') as HTMLInputElement | null;
       const _thunderRow = _idleOverlay.querySelector('.ski-idle-thunder-row') as HTMLElement | null;
@@ -11540,8 +11550,8 @@ function bindEvents() {
         nsExpirationMs = 0;
         nsNftOwner = null;
         _updateIdleStatus();
-        // Card updates on resolution, not keystrokes — only reset when input is cleared
-        if (!val) _updateIdleCard('');
+        _cardCacheKey = '';
+        _updateIdleCard(val || '');
         _renderThunderComposePreview();
         // Debounce fetch to avoid SuiNS rate limits
         if (_idleDebounce) clearTimeout(_idleDebounce);
@@ -11717,20 +11727,48 @@ function bindEvents() {
               const USDC_TYPE = '0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC';
               const PSM_RESERVE_ID = '0x62fcd184ef68d7267e4cf45f8af5ff7f23511c4741f26674875e691389ca264c';
               const addrN = (await import('@mysten/sui/utils')).normalizeSuiAddress(ws.address);
-              const rpcBody = (id: number, method: string, params: any[]) =>
-                JSON.stringify({ jsonrpc: '2.0', id, method, params });
-              const [suiRes, usdcRes, iusdRes, reserveRes] = await Promise.all([
-                fetch('https://sui-rpc.publicnode.com', { method: 'POST', headers: { 'content-type': 'application/json' }, body: rpcBody(1, 'suix_getBalance', [addrN, '0x2::sui::SUI']) }),
-                fetch('https://sui-rpc.publicnode.com', { method: 'POST', headers: { 'content-type': 'application/json' }, body: rpcBody(2, 'suix_getBalance', [addrN, USDC_TYPE]) }),
-                fetch('https://sui-rpc.publicnode.com', { method: 'POST', headers: { 'content-type': 'application/json' }, body: rpcBody(3, 'suix_getBalance', [addrN, IUSD_TYPE_UI]) }),
-                fetch('https://sui-rpc.publicnode.com', { method: 'POST', headers: { 'content-type': 'application/json' }, body: rpcBody(4, 'sui_getObject', [PSM_RESERVE_ID, { showContent: true }]) }),
-              ]);
-              const suiBal = BigInt(((await suiRes.json()) as { result?: { totalBalance?: string } }).result?.totalBalance ?? '0');
-              const usdcBal = BigInt(((await usdcRes.json()) as { result?: { totalBalance?: string } }).result?.totalBalance ?? '0');
-              const iusdBal = BigInt(((await iusdRes.json()) as { result?: { totalBalance?: string } }).result?.totalBalance ?? '0');
-              const reserveFields = ((await reserveRes.json()) as { result?: { data?: { content?: { fields?: { s_balance?: string; fee_bps?: string } } } } }).result?.data?.content?.fields;
-              const reserveUsdc = BigInt(reserveFields?.s_balance ?? '0');
-              const psmFeeBps = BigInt(reserveFields?.fee_bps ?? '50');
+              // Race multiple public RPC endpoints per call so a rate-limited or
+              // flaky publicnode can't falsely report a zero SUI balance — which
+              // used to route the buy into the PSM iUSD path even when the
+              // user had plenty of SUI, producing "PSM reserve too small" for
+              // trades that should have paid straight from gas.
+              const rpcEndpoints = [
+                'https://sui-rpc.publicnode.com',
+                'https://sui-mainnet-endpoint.blockvision.org',
+                'https://rpc.ankr.com/sui',
+              ];
+              const raceRpc = async (method: string, params: unknown[]): Promise<any> => {
+                const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+                const attempts = rpcEndpoints.map(async (url) => {
+                  const res = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body });
+                  if (!res.ok) throw new Error(`${url} ${res.status}`);
+                  const j = await res.json();
+                  if (j?.error || j?.result == null) throw new Error(`${url} rpc error`);
+                  return j.result;
+                });
+                return await Promise.any(attempts);
+              };
+              let suiBal = 0n, usdcBal = 0n, iusdBal = 0n, reserveUsdc = 0n, psmFeeBps = 50n;
+              try {
+                const [suiR, usdcR, iusdR, resvR] = await Promise.all([
+                  raceRpc('suix_getBalance', [addrN, '0x2::sui::SUI']),
+                  raceRpc('suix_getBalance', [addrN, USDC_TYPE]),
+                  raceRpc('suix_getBalance', [addrN, IUSD_TYPE_UI]),
+                  raceRpc('sui_getObject', [PSM_RESERVE_ID, { showContent: true }]),
+                ]);
+                suiBal = BigInt((suiR as { totalBalance?: string })?.totalBalance ?? '0');
+                usdcBal = BigInt((usdcR as { totalBalance?: string })?.totalBalance ?? '0');
+                iusdBal = BigInt((iusdR as { totalBalance?: string })?.totalBalance ?? '0');
+                const reserveFields = (resvR as { data?: { content?: { fields?: { s_balance?: string; fee_bps?: string } } } })?.data?.content?.fields;
+                reserveUsdc = BigInt(reserveFields?.s_balance ?? '0');
+                psmFeeBps = BigInt(reserveFields?.fee_bps ?? '50');
+              } catch (e) {
+                // All RPC endpoints failed. Rather than silently routing into
+                // the iUSD branch (which would fail with a confusing "PSM
+                // reserve" toast), bail out and ask the user to retry.
+                showToast('RPC unavailable — try again in a moment');
+                return;
+              }
 
               // Compute SUI shortfall, then USDC needed to swap to cover it.
               const priceMistBig = BigInt(priceMistStr);
@@ -11768,6 +11806,9 @@ function bindEvents() {
               nsAvail = 'owned'; nsTargetAddress = ws.address; nsLastDigest = digest ?? '';
               nsKioskListing = null; nsTradeportListing = null;
               app.suinsName = app.suinsName || domain;
+              // Persist the traded name so a hard refresh lands back on this
+              // card instead of going blank or snapping to the wallet primary.
+              try { localStorage.setItem('ski:ns-label', label); } catch {}
               showToast(`\u{1F6CD}\u{FE0F} ${domain} traded for ${totalSui.toFixed(2)} SUI (~$${priceUsd.toFixed(2)}) \u2713`);
               _updateIdleStatus();
               setTimeout(() => refreshPortfolio(true), PORTFOLIO_REFRESH_MED_MS);
@@ -11843,7 +11884,11 @@ function bindEvents() {
               }
             } finally {
               _idleActionBtn!.disabled = false;
-              _idleActionBtn!.textContent = 'TRADE';
+              // Re-evaluate the button based on current state instead of
+              // pinning it to 'TRADE' — after a successful purchase
+              // `nsAvail === 'owned'` and the listings are cleared, so the
+              // mode handler will swap it to SUIAMI automatically.
+              _updateSendBtnMode();
             }
             return;
           }
@@ -11916,13 +11961,22 @@ function bindEvents() {
               const regResult = await buildRegisterSplashNsTx(ws.address, `${label}.sui`, freshPrice, true, preferred);
               if (regResult?.txBytes) {
                 const _isWaaP = /waap/i.test(getState().walletName || '');
-                const { digest } = (!_isWaaP && regResult.sponsorAddress)
+                const { digest, effects: tradeEff } = (!_isWaaP && regResult.sponsorAddress)
                   ? await signAndExecuteSponsoredTx(regResult.txBytes)
                   : await signAndExecuteTransaction(regResult.txBytes);
                 nsAvail = 'owned';
+                nsTargetAddress = ws.address;
                 app.suinsName = app.suinsName || `${label}.sui`;
-                showToast(`\u{1F4DB} ${label}.sui registered \u2713`);
+                suinsCache[ws.address] = app.suinsName;
+                try { localStorage.setItem(`ski:suins:${ws.address}`, app.suinsName); } catch {}
+                updateSkiDot('blue-square', app.suinsName);
+                _patchNsPrice();
+                _patchNsStatus();
+                nsOwnedFetchedFor = '';
+                _fetchOwnedDomains();
                 _updateIdleStatus();
+                _updateIdleCard(label);
+                showMintToast(`${label}.sui`, digest, tradeEff);
                 setTimeout(() => refreshPortfolio(true), PORTFOLIO_REFRESH_MED_MS);
               } else {
                 showToast('Could not build registration transaction');
@@ -12073,11 +12127,18 @@ function bindEvents() {
                       try {
                         const regResult = await buildRegisterSplashNsTx(ws.address!, `${label}.sui`, undefined, true, 'NS');
                         if (regResult) {
-                          await signAndExecuteTransaction(regResult instanceof Uint8Array ? regResult : regResult);
-                          showToast(`\u2728 ${label}.sui minted!`);
-                          _idleActionBtn!.textContent = 'Minted';
-                          _idleActionBtn!.disabled = true;
+                          const { digest: questDigest, effects: questEff } = await signAndExecuteTransaction(regResult instanceof Uint8Array ? regResult : regResult);
+                          showMintToast(`${label}.sui`, questDigest, questEff);
                           nsAvail = 'owned';
+                          nsTargetAddress = ws.address!;
+                          app.suinsName = app.suinsName || `${label}.sui`;
+                          suinsCache[ws.address!] = app.suinsName;
+                          try { localStorage.setItem(`ski:suins:${ws.address!}`, app.suinsName); } catch {}
+                          updateSkiDot('blue-square', app.suinsName);
+                          _patchNsPrice();
+                          _patchNsStatus();
+                          nsOwnedFetchedFor = '';
+                          _fetchOwnedDomains();
                           _updateIdleStatus();
                           _updateIdleCard(label);
                           _preRumbledNames.add(label.toLowerCase());
@@ -13042,8 +13103,8 @@ function bindEvents() {
         const statusEl = _idleOverlay?.querySelector('#ski-idle-status') as HTMLElement | null;
         if (statusEl) statusEl.style.opacity = '0.3';
         try {
-          const { tx: setDefaultTx } = await buildSetDefaultNsTx(ws.address, domain);
-          const result = await signAndExecuteTransaction(setDefaultTx);
+          const { bytes: setDefaultBytes } = await buildSetDefaultNsTx(ws.address, domain);
+          const result = await signAndExecuteTransaction(setDefaultBytes);
           if (!result.digest) throw new Error('Transaction returned no digest');
           const eff = result.effects as Record<string, unknown> | undefined;
           const st = eff?.status as { status?: string; error?: string } | undefined;
@@ -16882,6 +16943,92 @@ function bindEvents() {
       _audioToggle.title = 'Unmute \u2192 BASMR';
       _audioToggle.textContent = '\u{1F507}';
       _idleOverlay?.appendChild(_audioToggle);
+
+      // Session countdown clock — sits next to the mute button, ticks down
+      // from the .SKI sign-in signature's `expiresAt`. Hidden when there's
+      // no active session (signed out / visitor mode). Updates once per
+      // second so the last hour reads MM:SS in real time, and drops back
+      // to days/hours formatting above the one-hour mark.
+      const _sessionClock = document.createElement('button');
+      _sessionClock.type = 'button';
+      _sessionClock.className = 'ski-idle-session-clock';
+      _sessionClock.textContent = '--:--';
+      _sessionClock.title = 'Click to re-sign Seal session';
+      _sessionClock.addEventListener('click', async (ev) => {
+        ev.stopPropagation();
+        if (_sessionClock.classList.contains('ski-idle-session-clock--busy')) return;
+        _sessionClock.classList.add('ski-idle-session-clock--busy');
+        const prevText = _sessionClock.textContent;
+        _sessionClock.textContent = '...';
+        try {
+          const { refreshSealSession } = await import('./client/thunder-stack.js');
+          const ok = await refreshSealSession();
+          if (!ok) _sessionClock.textContent = prevText ?? '--:--';
+        } catch {
+          _sessionClock.textContent = prevText ?? '--:--';
+        } finally {
+          _sessionClock.classList.remove('ski-idle-session-clock--busy');
+          _tickSessionClock();
+        }
+      });
+      _idleOverlay?.appendChild(_sessionClock);
+      // The "30-minute signature" users see is the Seal session key that
+      // gates Thunder/SUIAMI decrypt, minted via wallet-signed personal
+      // message and cached at `ski:seal-sk:v4:<addr>` with a fixed 30-min
+      // TTL. Expiry = creationTimeMs + ttlMin * 60_000. Pick the longest
+      // remaining across all addresses in case the user has multiple
+      // cached session keys (rare but cheap to handle).
+      const _readSessionExpiry = (): number => {
+        let best = 0;
+        try {
+          for (let i = 0; i < localStorage.length; i++) {
+            const k = localStorage.key(i);
+            if (!k || !k.startsWith('ski:seal-sk:v4:')) continue;
+            try {
+              const raw = localStorage.getItem(k);
+              if (!raw) continue;
+              const v = JSON.parse(raw) as { creationTimeMs?: number; ttlMin?: number };
+              if (typeof v?.creationTimeMs === 'number' && typeof v?.ttlMin === 'number') {
+                const exp = v.creationTimeMs + v.ttlMin * 60_000;
+                if (exp > best) best = exp;
+              }
+            } catch { /* skip malformed entry */ }
+          }
+        } catch { /* storage unavailable */ }
+        return best;
+      };
+      const _fmtSessionLeft = (ms: number): string => {
+        if (ms <= 0) return '0:00';
+        const sec = Math.floor(ms / 1000);
+        if (sec < 3600) {
+          const m = Math.floor(sec / 60);
+          const s = sec % 60;
+          return `${m}:${String(s).padStart(2, '0')}`;
+        }
+        const hr = Math.floor(sec / 3600);
+        if (hr < 24) return `${hr}h ${Math.floor((sec % 3600) / 60)}m`;
+        return `${Math.floor(hr / 24)}d ${hr % 24}h`;
+      };
+      const _tickSessionClock = () => {
+        const expiresAt = _readSessionExpiry();
+        const ms = expiresAt ? expiresAt - Date.now() : 0;
+        // Always keep the bubble visible (ski-clock motif). If no session or
+        // expired, show dashes so the element still reads as a clock.
+        _sessionClock.hidden = false;
+        if (ms > 0) {
+          _sessionClock.textContent = _fmtSessionLeft(ms);
+          _sessionClock.title = `.SKI session expires ${new Date(expiresAt).toLocaleString()}`;
+          _sessionClock.classList.toggle('ski-idle-session-clock--warn', ms < 60 * 60 * 1000 && ms >= 5 * 60 * 1000);
+          _sessionClock.classList.toggle('ski-idle-session-clock--crit', ms < 5 * 60 * 1000);
+        } else {
+          _sessionClock.textContent = '--:--';
+          _sessionClock.title = 'No active .SKI session';
+          _sessionClock.classList.remove('ski-idle-session-clock--warn');
+          _sessionClock.classList.remove('ski-idle-session-clock--crit');
+        }
+      };
+      _tickSessionClock();
+      setInterval(_tickSessionClock, 1000);
       _audioToggle.addEventListener('click', async (ev) => {
         ev.stopPropagation();
         if (!_idleVideo) return;

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -455,34 +455,53 @@ export async function signPersonalMessage(message: Uint8Array): Promise<{
  *
  * Sui signature: flag(1) + r(32) + s(32) + pubkey(33) = 98 bytes.
  * WaaP occasionally produces 97-byte sigs when r or s is only 31 bytes
- * (leading zero stripped). We detect which component is short and zero-pad it.
+ * (leading zero stripped, since RFC-6979 ECDSA outputs the integers
+ * minimally-encoded). Sui's RPC rejects with "expected 64 bytes and got 63".
  *
- * Heuristic: try padding r first (prepend 0x00 before r). If the resulting
- * s would start with a byte > 0x7F that's unlikely for a valid s value of
- * a 256-bit curve, swap and pad s instead. In practice both r and s are
- * uniformly random so either pad position produces a valid-length sig —
- * the RPC will reject if we guessed wrong, so we just try r-pad (most common).
+ * We can't tell from the bytes alone which side is short, so we return
+ * BOTH candidate paddings and let the executor try them in order.
+ *
+ *   r-pad: [flag] [0x00] [shortSig 63] [pubkey]   ← short side was r
+ *   s-pad: [flag] [shortSig[0..32]] [0x00] [shortSig[32..63]] [pubkey]
+ *                                          ← short side was s (insert before s)
  */
-function _padSecp256k1Sig(sig: string): string {
+function _padShortEcdsaSigCandidates(sig: string): string[] {
   const raw = Uint8Array.from(atob(sig), c => c.charCodeAt(0));
   // secp256k1 flag=0x01, secp256r1 flag=0x02 — both have 33-byte compressed pubkey
-  if (raw.length !== 97 || (raw[0] !== 0x01 && raw[0] !== 0x02)) return sig;
-  // raw layout: [flag(1)] [raw_sig(63)] [pubkey(33)]
+  if (raw.length !== 97 || (raw[0] !== 0x01 && raw[0] !== 0x02)) return [sig];
   const flag = raw[0];
-  const rawSig = raw.subarray(1, 64);   // 63 bytes
+  const rawSig = raw.subarray(1, 64);   // 63 bytes (the short r||s)
   const pubkey = raw.subarray(64);       // 33 bytes
 
-  // Pad r (most common): r becomes 32 bytes, s stays 31→ no, total must be 64
-  // If raw_sig is 63 bytes = r(31) + s(32) → pad r
-  const fixed = new Uint8Array(98);
-  fixed[0] = flag;
-  // fixed[1] = 0x00 (pad byte for r, already zero)
-  fixed.set(rawSig, 2);    // 63 bytes at offset 2 → fills [2..64]
-  fixed.set(pubkey, 65);   // 33 bytes at offset 65 → fills [65..97]
+  const toB64 = (u: Uint8Array): string => {
+    let s = '';
+    for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]);
+    return btoa(s);
+  };
 
-  let b64 = '';
-  for (let i = 0; i < fixed.length; i++) b64 += String.fromCharCode(fixed[i]);
-  return btoa(b64);
+  // Candidate A — r was short: prepend 0x00 to rawSig (treat all 63 as s + r-low)
+  // Layout: [flag][0x00][rawSig 63][pubkey 33]
+  // After pad: r = 0x00 || rawSig[0..31] (32 bytes), s = rawSig[31..63] (32 bytes)
+  const rPad = new Uint8Array(98);
+  rPad[0] = flag;
+  rPad.set(rawSig, 2);
+  rPad.set(pubkey, 65);
+
+  // Candidate B — s was short: r is rawSig[0..32] (32 bytes), insert 0x00 before s
+  // Layout: [flag][rawSig[0..32]][0x00][rawSig[32..63]][pubkey]
+  const sPad = new Uint8Array(98);
+  sPad[0] = flag;
+  sPad.set(rawSig.subarray(0, 32), 1);   // r (32 bytes) → [1..33]
+  // sPad[33] = 0x00 (already zero) → s leading pad
+  sPad.set(rawSig.subarray(32, 63), 34); // s low 31 bytes → [34..65]
+  sPad.set(pubkey, 65);
+
+  return [toB64(rPad), toB64(sPad)];
+}
+
+/** True when a wallet error message looks like a short-ECDSA-sig rejection from Sui. */
+function _isShortSigError(msg: string): boolean {
+  return /expected 64 bytes.*got 63|got 63.*expected 64|signature.*length|invalid signature/i.test(msg);
 }
 
 // ─── Execute signed tx via gRPC → JSON-RPC fallback ─────────────────
@@ -543,6 +562,39 @@ export async function signAndExecuteTransaction(transaction: unknown): Promise<{
           return { digest: r.digest || '', effects: r.effects };
         } catch (waapErr: unknown) {
           const msg = waapErr instanceof Error ? waapErr.message : String(waapErr);
+
+          // Short-ECDSA-sig fallback: WaaP secp256k1/r1 occasionally drops a
+          // leading zero from r or s, producing a 63-byte raw sig. Sui rejects
+          // with "expected 64 bytes and got 63". Re-sign in sign-only mode,
+          // pad the candidate sigs, execute via our own transport.
+          if (_isShortSigError(msg)) {
+            console.warn('[.SKI] WaaP short-ECDSA-sig detected — falling back to sign-only + pad + execute.', msg);
+            try {
+              const signFeat = wallet.features['sui:signTransaction'] as {
+                signTransaction: (input: { transaction: unknown; account: WalletAccount; chain: string }) => Promise<{ bytes: string; signature: string }>;
+              } | undefined;
+              if (!signFeat) throw waapErr;
+              const signed = await signFeat.signTransaction({
+                transaction: transaction instanceof Uint8Array ? augmentBytes(transaction) : transaction,
+                account, chain,
+              });
+              // Use the bytes WaaP returned (= bytes WaaP actually signed),
+              // not the bytes we sent — the iframe may have re-serialized.
+              const txBytes = Uint8Array.from(atob(signed.bytes), c => c.charCodeAt(0));
+              const candidates = _padShortEcdsaSigCandidates(signed.signature);
+              let lastErr: unknown = waapErr;
+              for (const sig of candidates) {
+                try {
+                  return await raceExecuteTransaction(txBytes, [sig]);
+                } catch (e) { lastErr = e; }
+              }
+              throw lastErr;
+            } catch (fallbackErr) {
+              console.error('[.SKI] WaaP short-sig fallback failed.', fallbackErr);
+              throw fallbackErr;
+            }
+          }
+
           // Surface WaaP-specific errors with actionable context
           if (msg.includes('Invalid') && msg.includes('signature')) {
             console.error('[.SKI] WaaP signing failed — likely a WaaP server-side session issue.', msg);


### PR DESCRIPTION
## Evolutions in this PR

**Xatu — SUIAMI verified caps + `who()` reverse lookup** (92a7ae0)
Flips `IdentityRecord.verified` on-chain by threading DWalletCap IDs through roster writes. New `readRosterByChain()` + `who("chain:addr")` console helper for reverse lookup. Thunder bubble SUIAMI enrichment. Addresses 3 of 4 "Underutilized Contract Features" from the SUIAMI doc.

**Magneton — Seal refresh chip, WaaP short-sig, Tradeport resolver** (ed3b91e)
`refreshSealSession()` for idle-overlay countdown. Short-ECDSA padding retry for WaaP jitter. New tradeport listing resolver + kiosk fix. Misc UI polish.

**Porygon — CF edge enrichment substrate** (#160, commits 33e0df8 + a9ad9e7)
Two Move contract additions for the upcoming CF-history feature:
- `cf_history` storage as a separate dynamic field keyed by `CfHistoryKey{addr}` — additive, no `IdentityRecord` struct change, no BCS break.
- `seal_approve_cf_history` personal-decrypt Seal policy (only record owner decrypts).
- Granular mutators: `set_walrus_blob`, `set_dwallet_caps` (rewrite all three indexes via `rewrite_indexes` helper; prevents drift).
- `revoke_identity` — feints all three index copies + cf_history store.
- Tightened `seal_approve_roster_reader` with `id[0..32] == sender` prefix check.

Contracts build clean. No publish yet — Porygon2 evolution is branch-side only; Task 4 (mainnet upgrade) happens after this merge.

## Spec + plan

- `docs/superpowers/specs/2026-04-16-cf-edge-enrichment-design.md`
- `docs/superpowers/plans/2026-04-16-cf-edge-enrichment.md` (11 moves total, 3 landed)

## SUIAMI review

Fold-in summary landed in Porygon Sharpen commit. Items 2/5/7 deferred to future Pokemon.

## Test plan
- [ ] `bun run build` clean
- [ ] `sui move build` clean for contracts/suiami
- [ ] Existing SUIAMI write flows exercised on sui.ski (no regressions from Xatu/Magneton)