### PR TITLE
Porygon evolves — CF edge enrichment live (v2 pkg + lazy roster write)

### DIFF
--- a/contracts/suiami/Move.toml
+++ b/contracts/suiami/Move.toml
@@ -1,7 +1,7 @@
 [package]
 name = "suiami"
 edition = "2024.beta"
-published-at = "0x2c1d63b3b314f9b6e96c33e9a3bca4faaa79a69a5729e5d2e8ac09d70e1052fa"
+published-at = "0x7bf4438feaf953e94b98dfc2aab0cf1aaad2250ee4e0fe87c9cc251965987de8"
 
 [dependencies]
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "framework/mainnet" }

--- a/src/client/cf-history.ts
+++ b/src/client/cf-history.ts
@@ -1,11 +1,16 @@
 // Porygon — CF edge enrichment client.
 //
 // Fetches signed CF metadata from the worker, change-detects against
-// the tail chunk (so typical users produce 1-3 lifetime chunks, not
-// hundreds), Seal-encrypts, uploads to Walrus, and returns the new
-// blob ID for inclusion in a roster-write PTB.
+// a localStorage-cached fingerprint (no decrypt roundtrip), Seal-
+// encrypts, uploads to Walrus, and appends the `append_cf_history`
+// moveCall to the caller's PTB.
+//
+// Called from suins.ts's `buildWithTx` chokepoint so every PTB that
+// newly writes the SUIAMI roster also writes a CF chunk if the
+// fingerprint has changed. Typical user: 1-3 chunks lifetime.
 
-import { encryptCfChunkToWalrus, decryptCfChunkForAddress } from './suiami-seal.js';
+import type { Transaction } from '@mysten/sui/transactions';
+import { encryptCfChunkToWalrus, decryptCfChunkForAddress, SUIAMI_PKG, ROSTER_OBJ, ROSTER_INITIAL_SHARED_VERSION } from './suiami-seal.js';
 
 export interface CfFields {
   country: string;
@@ -21,16 +26,20 @@ export interface CfFields {
 export interface CfEnvelope { data: CfFields; sig: string }
 export interface CfChunk { schema: 1; data: CfFields; sig: string }
 
-/** Fields compared for change-detection. Everything except
- *  `attestedAt` — a new chunk only gets written when something real
- *  about the user's edge context changes. */
+/** Fields compared for change-detection. Excludes `attestedAt` so
+ *  timestamp noise doesn't trigger writes. */
 const CHANGE_KEYS: Array<keyof CfFields> = [
   'country', 'asn', 'threatScore', 'ipHash', 'colo',
   'verifiedBot', 'tlsVersion', 'httpProtocol',
 ];
 
-function fingerprintsMatch(a: CfFields, b: CfFields): boolean {
-  return CHANGE_KEYS.every((k) => a[k] === b[k]);
+/** localStorage key for the last-written fingerprint per address. */
+const CF_LS_KEY = (addr: string) => `ski:cf-hist:v1:${addr.toLowerCase()}`;
+
+function fingerprintOf(data: CfFields): string {
+  const sorted: Record<string, unknown> = {};
+  for (const k of CHANGE_KEYS) sorted[k] = data[k];
+  return JSON.stringify(sorted);
 }
 
 export async function fetchCfContext(): Promise<CfEnvelope | null> {
@@ -43,43 +52,57 @@ export async function fetchCfContext(): Promise<CfEnvelope | null> {
   }
 }
 
-/** Decide whether to write a new CF chunk. Returns the Walrus blob
- *  ID of the freshly-uploaded chunk, or null when the fingerprint is
- *  unchanged (no write needed). Caller then passes the blob ID into
- *  `append_cf_history` as part of the enclosing roster-write PTB.
+/** Append a `roster::append_cf_history` moveCall to the given tx, but
+ *  only when the CF fingerprint has changed since the last local
+ *  write. Silently no-ops on mainnet miss, network error, or unchanged
+ *  fingerprint. Never throws — CF enrichment is best-effort.
  *
- *  When `tailBlobId` is provided, we decrypt the prior chunk and
- *  compare fingerprints before writing. On decrypt failure (network,
- *  expired session key) we fall back to writing — staleness is
- *  preferable to a silent history gap. */
-export async function maybeBuildCfChunk(opts: {
-  ownerAddress: string;
-  tailBlobId: string;
-  signPersonalMessage: (msg: Uint8Array) => Promise<{ signature: string }>;
-}): Promise<string | null> {
-  const env = await fetchCfContext();
-  if (!env) return null;
-  if (opts.tailBlobId) {
-    try {
-      const prev = (await decryptCfChunkForAddress({
-        blobId: opts.tailBlobId,
-        address: opts.ownerAddress,
-        signPersonalMessage: opts.signPersonalMessage,
-      })) as CfChunk | null;
-      if (prev?.data && fingerprintsMatch(prev.data, env.data)) {
-        return null;
-      }
-    } catch {
-      // Fall through to write.
-    }
+ *  Uses localStorage as the change-detect oracle (not the Walrus blob)
+ *  so we don't need a SessionKey / wallet prompt to decide whether to
+ *  write. First-time writers always write (no cached fingerprint). */
+export async function maybeAttachCfHistoryToTx(
+  tx: Transaction,
+  ownerAddress: string,
+): Promise<boolean> {
+  // Idempotency guard — a single tx should carry at most one CF chunk
+  // write, regardless of how many code paths try to attach it.
+  const txAny = tx as unknown as { _cfAttached?: boolean };
+  if (txAny._cfAttached) return false;
+  try {
+    const env = await fetchCfContext();
+    if (!env) return false;
+    const currentFp = fingerprintOf(env.data);
+    let priorFp = '';
+    try { priorFp = localStorage.getItem(CF_LS_KEY(ownerAddress)) ?? ''; } catch {}
+    if (priorFp === currentFp) return false;
+
+    const chunk: CfChunk = { schema: 1, data: env.data, sig: env.sig };
+    const { blobId } = await encryptCfChunkToWalrus(ownerAddress, chunk);
+
+    tx.moveCall({
+      target: `${SUIAMI_PKG}::roster::append_cf_history`,
+      arguments: [
+        tx.sharedObjectRef({
+          objectId: ROSTER_OBJ,
+          initialSharedVersion: ROSTER_INITIAL_SHARED_VERSION,
+          mutable: true,
+        }),
+        tx.pure.string(blobId),
+        tx.object('0x6'),
+      ],
+    });
+
+    try { localStorage.setItem(CF_LS_KEY(ownerAddress), currentFp); } catch {}
+    txAny._cfAttached = true;
+    return true;
+  } catch (err) {
+    console.warn('[cf-history] attach failed (non-fatal):', err instanceof Error ? err.message : err);
+    return false;
   }
-  const chunk: CfChunk = { schema: 1, data: env.data, sig: env.sig };
-  const { blobId } = await encryptCfChunkToWalrus(opts.ownerAddress, chunk);
-  return blobId;
 }
 
-/** Decrypt and return the full CF history for the caller. Returns an
- *  empty array if the user has no cf_history or every decrypt fails. */
+/** Decrypt and return the full CF history for the caller. Used by
+ *  the `cfHistory()` console helper — requires a wallet session key. */
 export async function readCfHistory(opts: {
   ownerAddress: string;
   blobIds: string[];

--- a/src/client/cf-history.ts
+++ b/src/client/cf-history.ts
@@ -1,0 +1,98 @@
+// Porygon — CF edge enrichment client.
+//
+// Fetches signed CF metadata from the worker, change-detects against
+// the tail chunk (so typical users produce 1-3 lifetime chunks, not
+// hundreds), Seal-encrypts, uploads to Walrus, and returns the new
+// blob ID for inclusion in a roster-write PTB.
+
+import { encryptCfChunkToWalrus, decryptCfChunkForAddress } from './suiami-seal.js';
+
+export interface CfFields {
+  country: string;
+  asn: number;
+  threatScore: number;
+  ipHash: string;
+  colo: string;
+  verifiedBot: boolean;
+  tlsVersion: string;
+  httpProtocol: string;
+  attestedAt: number;
+}
+export interface CfEnvelope { data: CfFields; sig: string }
+export interface CfChunk { schema: 1; data: CfFields; sig: string }
+
+/** Fields compared for change-detection. Everything except
+ *  `attestedAt` — a new chunk only gets written when something real
+ *  about the user's edge context changes. */
+const CHANGE_KEYS: Array<keyof CfFields> = [
+  'country', 'asn', 'threatScore', 'ipHash', 'colo',
+  'verifiedBot', 'tlsVersion', 'httpProtocol',
+];
+
+function fingerprintsMatch(a: CfFields, b: CfFields): boolean {
+  return CHANGE_KEYS.every((k) => a[k] === b[k]);
+}
+
+export async function fetchCfContext(): Promise<CfEnvelope | null> {
+  try {
+    const res = await fetch('/api/cf-context');
+    if (!res.ok) return null;
+    return (await res.json()) as CfEnvelope;
+  } catch {
+    return null;
+  }
+}
+
+/** Decide whether to write a new CF chunk. Returns the Walrus blob
+ *  ID of the freshly-uploaded chunk, or null when the fingerprint is
+ *  unchanged (no write needed). Caller then passes the blob ID into
+ *  `append_cf_history` as part of the enclosing roster-write PTB.
+ *
+ *  When `tailBlobId` is provided, we decrypt the prior chunk and
+ *  compare fingerprints before writing. On decrypt failure (network,
+ *  expired session key) we fall back to writing — staleness is
+ *  preferable to a silent history gap. */
+export async function maybeBuildCfChunk(opts: {
+  ownerAddress: string;
+  tailBlobId: string;
+  signPersonalMessage: (msg: Uint8Array) => Promise<{ signature: string }>;
+}): Promise<string | null> {
+  const env = await fetchCfContext();
+  if (!env) return null;
+  if (opts.tailBlobId) {
+    try {
+      const prev = (await decryptCfChunkForAddress({
+        blobId: opts.tailBlobId,
+        address: opts.ownerAddress,
+        signPersonalMessage: opts.signPersonalMessage,
+      })) as CfChunk | null;
+      if (prev?.data && fingerprintsMatch(prev.data, env.data)) {
+        return null;
+      }
+    } catch {
+      // Fall through to write.
+    }
+  }
+  const chunk: CfChunk = { schema: 1, data: env.data, sig: env.sig };
+  const { blobId } = await encryptCfChunkToWalrus(opts.ownerAddress, chunk);
+  return blobId;
+}
+
+/** Decrypt and return the full CF history for the caller. Returns an
+ *  empty array if the user has no cf_history or every decrypt fails. */
+export async function readCfHistory(opts: {
+  ownerAddress: string;
+  blobIds: string[];
+  signPersonalMessage: (msg: Uint8Array) => Promise<{ signature: string }>;
+}): Promise<CfChunk[]> {
+  const out: CfChunk[] = [];
+  for (const id of opts.blobIds) {
+    const chunk = (await decryptCfChunkForAddress({
+      blobId: id,
+      address: opts.ownerAddress,
+      signPersonalMessage: opts.signPersonalMessage,
+    })) as CfChunk | null;
+    if (chunk) out.push(chunk);
+  }
+  return out;
+}

--- a/src/client/suiami-seal.ts
+++ b/src/client/suiami-seal.ts
@@ -53,7 +53,7 @@ import { SuiGraphQLClient } from '@mysten/sui/graphql';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 import { grpcClient, GQL_URL } from '../rpc.js';
 
-export const SUIAMI_PKG = '0x2c1d63b3b314f9b6e96c33e9a3bca4faaa79a69a5729e5d2e8ac09d70e1052fa';
+export const SUIAMI_PKG = '0x7bf4438feaf953e94b98dfc2aab0cf1aaad2250ee4e0fe87c9cc251965987de8';
 export const ROSTER_OBJ = '0x30b45c51a34b20b5ab99e8c493a82c332e9502e5f4380d1be6cc79e712eaab1d';
 export const ROSTER_INITIAL_SHARED_VERSION = 839068132;
 

--- a/src/client/suiami-seal.ts
+++ b/src/client/suiami-seal.ts
@@ -314,6 +314,107 @@ export async function decryptSquidsForName(opts: {
   return JSON.parse(new TextDecoder().decode(plaintext));
 }
 
+// ─── CF history (Porygon) ───────────────────────────────────────────
+//
+// Same Seal infrastructure as the squid path, but targets the
+// `seal_approve_cf_history` personal policy. Only the record owner
+// can decrypt their own CF chunks. Deterministic 40-byte Seal id =
+// 32-byte sender address ‖ 8 zero bytes — every one of a user's
+// chunks shares the same id so a single session-key approval
+// decrypts the whole history.
+
+/** Derive the deterministic Seal id for a wallet's CF-history chunks.
+ *  Matches the on-chain `seal_approve_cf_history` prefix check which
+ *  asserts `id[0..32] == sender address bytes`. */
+export function deriveCfHistorySealId(address: string): { bytes: Uint8Array; hex: string } {
+  const clean = address.toLowerCase().replace(/^0x/, '').padStart(64, '0');
+  const bytes = new Uint8Array(40);
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  // Last 8 bytes stay zero — nothing to do.
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return { bytes, hex };
+}
+
+/** Encrypt a CF chunk under the personal cf-history policy and upload
+ *  to Walrus. Returns the blob id for inclusion in a roster write PTB. */
+export async function encryptCfChunkToWalrus(
+  address: string,
+  chunk: unknown,
+): Promise<{ blobId: string }> {
+  const { hex: sealIdHex } = deriveCfHistorySealId(address);
+  const plaintext = new TextEncoder().encode(JSON.stringify(chunk));
+
+  const { encryptedObject } = await sealRace((c) =>
+    c.encrypt({
+      packageId: SUIAMI_PKG,
+      id: sealIdHex,
+      data: plaintext,
+      threshold: 2,
+    }),
+  );
+
+  const res = await fetch(`${WALRUS_PUBLISHER}/v1/blobs`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/octet-stream' },
+    body: encryptedObject,
+  });
+  if (!res.ok) {
+    throw new Error(`Walrus upload failed: ${res.status} ${res.statusText}`);
+  }
+  const result = (await res.json()) as { newlyCreated?: { blobObject?: { blobId?: string } }; alreadyCertified?: { blobId?: string } };
+  const blobId = result?.newlyCreated?.blobObject?.blobId ?? result?.alreadyCertified?.blobId;
+  if (!blobId) throw new Error('Walrus upload: no blobId in response');
+  return { blobId };
+}
+
+/** Decrypt a single CF chunk by Walrus blob id. Requires the caller
+ *  to be the record owner — the personal Seal policy enforces this. */
+export async function decryptCfChunkForAddress(opts: {
+  blobId: string;
+  address: string;
+  signPersonalMessage: (msg: Uint8Array) => Promise<{ signature: string }>;
+}): Promise<unknown | null> {
+  const fetchRes = await fetch(`${WALRUS_AGGREGATOR}/v1/blobs/${opts.blobId}`);
+  if (!fetchRes.ok) return null;
+  const encryptedObject = new Uint8Array(await fetchRes.arrayBuffer());
+  const { bytes: sealIdBytes } = deriveCfHistorySealId(opts.address);
+
+  const tx = new Transaction();
+  tx.moveCall({
+    target: `${SUIAMI_PKG}::seal_roster::seal_approve_cf_history`,
+    arguments: [
+      tx.sharedObjectRef({
+        objectId: ROSTER_OBJ,
+        initialSharedVersion: ROSTER_INITIAL_SHARED_VERSION,
+        mutable: false,
+      }),
+      tx.pure.vector('u8', Array.from(sealIdBytes)),
+    ],
+  });
+  const txBytes = await tx.build({
+    client: grpcClient as never,
+    onlyTransactionKind: true,
+  });
+
+  const sessionKey = await getSuiamiSessionKey(opts.address, opts.signPersonalMessage);
+  try {
+    const plaintext = await sealRace((c) =>
+      c.decrypt({
+        data: encryptedObject,
+        sessionKey,
+        txBytes,
+      }),
+    );
+    return JSON.parse(new TextDecoder().decode(plaintext));
+  } catch {
+    return null;
+  }
+}
+
 /** Clear any cached SUIAMI session key. For tests and the wallet's
  *  "disconnect" event, same pattern as clearSealCache() for thunder. */
 export function clearSuiamiSessionCache(address?: string): void {

--- a/src/server/agents/treasury-agents.ts
+++ b/src/server/agents/treasury-agents.ts
@@ -7362,7 +7362,7 @@ export class TreasuryAgents extends Agent<Env, TreasuryAgentsState> {
       if (status.ethAddress) { chainKeys.push('eth'); chainVals.push(status.ethAddress); }
       if (status.solAddress) { chainKeys.push('sol'); chainVals.push(status.solAddress); }
 
-      const ROSTER_PKG = '0x2c1d63b3b314f9b6e96c33e9a3bca4faaa79a69a5729e5d2e8ac09d70e1052fa';
+      const ROSTER_PKG = '0x7bf4438feaf953e94b98dfc2aab0cf1aaad2250ee4e0fe87c9cc251965987de8';
       const ROSTER_OBJ = '0x30b45c51a34b20b5ab99e8c493a82c332e9502e5f4380d1be6cc79e712eaab1d';
 
       const tx = new Transaction();

--- a/src/server/cf-context.ts
+++ b/src/server/cf-context.ts
@@ -1,0 +1,81 @@
+// CF edge context endpoint for SUIAMI CF-history enrichment.
+// Returns HMAC-signed CF metadata the client encrypts + uploads to Walrus.
+//
+// Nine fields, all sourced from request.cf + headers. HMAC is for
+// tamper-evidence so future consumers can verify the data came from
+// our edge — the data itself is user-known, not secret.
+
+export interface CfFields {
+  country: string;
+  asn: number;
+  threatScore: number;
+  ipHash: string;
+  colo: string;
+  verifiedBot: boolean;
+  tlsVersion: string;
+  httpProtocol: string;
+  attestedAt: number;
+}
+
+export interface CfContextResponse {
+  data: CfFields;
+  sig: string;
+}
+
+/** Canonical JSON — sorted keys, no whitespace. Stable across clients. */
+function canonicalize(data: CfFields): string {
+  const sorted: Record<string, unknown> = {};
+  for (const k of Object.keys(data).sort()) {
+    sorted[k] = (data as unknown as Record<string, unknown>)[k];
+  }
+  return JSON.stringify(sorted);
+}
+
+async function hmac(secret: string, msg: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(msg));
+  return [...new Uint8Array(sig)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function handleCfContext(
+  req: Request,
+  env: { CF_HMAC_SECRET?: string; CF_IP_SALT?: string },
+): Promise<Response> {
+  if (!env.CF_HMAC_SECRET || !env.CF_IP_SALT) {
+    return new Response(JSON.stringify({ error: 'cf-context not configured' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  const cf = (req as unknown as { cf?: Record<string, unknown> }).cf ?? {};
+  const ip = req.headers.get('cf-connecting-ip') ?? '';
+  const data: CfFields = {
+    country: String(req.headers.get('cf-ipcountry') ?? cf.country ?? 'XX'),
+    asn: Number(cf.asn ?? 0),
+    threatScore: Number(cf.threatScore ?? 0),
+    ipHash: ip ? await sha256Hex(env.CF_IP_SALT + '\x1f' + ip) : '',
+    colo: String(cf.colo ?? ''),
+    verifiedBot: Boolean(cf.verifiedBot ?? false),
+    tlsVersion: String(cf.tlsVersion ?? ''),
+    httpProtocol: String(cf.httpProtocol ?? ''),
+    attestedAt: Date.now(),
+  };
+  const sig = await hmac(env.CF_HMAC_SECRET, canonicalize(data));
+  return new Response(JSON.stringify({ data, sig }), {
+    headers: {
+      'content-type': 'application/json',
+      'cache-control': 'no-store',
+    },
+  });
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,8 @@ interface Env {
   ALCHEMY_ETH_URL?: string; // Alchemy ETH mainnet HTTPS endpoint (viem transport)
   ZKLOGIN_PROVER_URL?: string; // zkLogin prover upstream (devnet vampire / mainnet self-host)
   ENCRYPT_GRPC_URL?: string; // dWallet Encrypt upstream (pre-alpha devnet)
+  CF_HMAC_SECRET?: string; // HMAC-SHA256 key for /api/cf-context signed envelopes
+  CF_IP_SALT?: string; // SHA-256 salt for ipHash in CF edge context
 }
 
 const app = new Hono<{ Bindings: Env }>();
@@ -38,6 +40,15 @@ const app = new Hono<{ Bindings: Env }>();
 // Encrypt: stub mode until pre-alpha exposes gRPC-Web or grpc-gateway.
 app.route('/api/zklogin', createZkLoginApp());
 app.route('/api/encrypt', encryptProxy);
+
+// ── CF edge context for SUIAMI CF-history enrichment ────────────────
+// Returns HMAC-signed CF metadata the client encrypts + uploads to
+// Walrus. Read-only, no rate-limit concerns beyond the generic /api/*
+// limiter below.
+app.get('/api/cf-context', async (c) => {
+  const { handleCfContext } = await import('./cf-context.js');
+  return handleCfContext(c.req.raw, c.env as { CF_HMAC_SECRET?: string; CF_IP_SALT?: string });
+});
 
 // ── Rate limiting middleware ────────────────────────────────────────────
 // Simple per-IP sliding window. Uses in-memory Map (resets on cold start).

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1900,7 +1900,7 @@ app.post('/api/cache/ultron-roster', async (c) => {
     const name = 'ultron';
     const nameHash = Array.from(keccak_256(new TextEncoder().encode(name)));
 
-    const ROSTER_PKG = '0x2c1d63b3b314f9b6e96c33e9a3bca4faaa79a69a5729e5d2e8ac09d70e1052fa';
+    const ROSTER_PKG = '0x7bf4438feaf953e94b98dfc2aab0cf1aaad2250ee4e0fe87c9cc251965987de8';
     const ROSTER_OBJ = '0x30b45c51a34b20b5ab99e8c493a82c332e9502e5f4380d1be6cc79e712eaab1d';
 
     const tx = new Transaction();

--- a/src/ski.ts
+++ b/src/ski.ts
@@ -480,6 +480,12 @@ window.addEventListener('ski:request-suiami', async (e) => {
         dwalletCaps = (await getCrossChainStatus(ws.address)).dwalletCaps ?? [];
       } catch {}
       maybeAppendRoster(tx, ws.address, name, undefined, blobId, sealNonce, dwalletCaps);
+      // Piggyback CF edge enrichment (Porygon) — lazy, change-detected,
+      // best-effort. Non-fatal on failure; never blocks SUIAMI write.
+      try {
+        const { maybeAttachCfHistoryToTx } = await import('./client/cf-history.js');
+        await maybeAttachCfHistoryToTx(tx, ws.address);
+      } catch {}
       // Pre-build to bytes so WaaP's v1 SDK doesn't crash reading
       // gasConfig.price (v2 uses gasData, v1 reads gasConfig).
       const rosterBytes = await tx.build({ client: grpcClient as never });

--- a/src/ski.ts
+++ b/src/ski.ts
@@ -826,6 +826,83 @@ const _who = async (input: string) => {
 (globalThis as unknown as { who: typeof _who }).who = _who;
 console.log('[ski] who hook installed — call who("<chain>:<address>") or who("<bare-0x-addr>") for reverse roster lookup');
 
+// ── cfHistory() — Porygon CF-edge timeline ──
+//
+// Reads the caller's cf_history Walrus blob IDs off-chain (via GraphQL
+// on the Roster shared object's dynamic_field), decrypts each chunk
+// via Seal, prints a sparse timeline. Prompts for a SessionKey the
+// first call in a 30-min window.
+const _cfHistory = async () => {
+  try {
+    const ws = getState();
+    if (ws.status !== 'connected' || !ws.address) {
+      console.error('[cfHistory] no wallet connected');
+      return;
+    }
+    const addr = ws.address.toLowerCase();
+    const raw = new Uint8Array(32);
+    const hex = addr.replace(/^0x/, '').padStart(64, '0');
+    for (let i = 0; i < 32; i++) raw[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    const addrB64 = btoa(String.fromCharCode(...raw));
+    const { SUIAMI_PKG, ROSTER_OBJ } = await import('./client/suiami-seal.js');
+    const { GQL_URL } = await import('./rpc.js');
+
+    // Try both possible type paths for CfHistoryKey — Sui type tags
+    // for structs added in an upgrade can be qualified by either the
+    // original or the upgraded package ID depending on indexer.
+    const typePaths = [
+      `${SUIAMI_PKG}::roster::CfHistoryKey`,
+      `0x2c1d63b3b314f9b6e96c33e9a3bca4faaa79a69a5729e5d2e8ac09d70e1052fa::roster::CfHistoryKey`,
+    ];
+    let json: { blobs?: string[]; updated_ms?: string } | null = null;
+    for (const t of typePaths) {
+      try {
+        const res = await fetch(GQL_URL, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            query: `{ object(address: "${ROSTER_OBJ}") { dynamicField(name: { type: "${t}", bcs: "${addrB64}" }) { value { ... on MoveValue { json } } } } }`,
+          }),
+        });
+        const gql = await res.json() as { data?: { object?: { dynamicField?: { value?: { json?: unknown } } } } };
+        const candidate = gql?.data?.object?.dynamicField?.value?.json as { blobs?: string[]; updated_ms?: string } | undefined;
+        if (candidate?.blobs) { json = candidate; break; }
+      } catch {}
+    }
+    const blobIds = json?.blobs ?? [];
+    if (blobIds.length === 0) {
+      console.log('[cfHistory] empty — no CF chunks written yet');
+      return;
+    }
+    console.log(`[cfHistory] ${blobIds.length} chunk(s) on-chain, decrypting\u2026`);
+
+    const { readCfHistory } = await import('./client/cf-history.js');
+    const { signPersonalMessage } = await import('./wallet.js');
+    const chunks = await readCfHistory({
+      ownerAddress: ws.address,
+      blobIds,
+      signPersonalMessage,
+    });
+    if (chunks.length === 0) {
+      console.log('[cfHistory] all decrypts failed — Seal key servers or session-key issue');
+      return;
+    }
+    // Sort by attestedAt ascending
+    chunks.sort((a, b) => (a.data.attestedAt ?? 0) - (b.data.attestedAt ?? 0));
+    for (const c of chunks) {
+      const d = c.data;
+      const ts = new Date(d.attestedAt).toISOString();
+      console.log(`[cfHistory] ${ts}  ${d.country}/${d.colo}  ASN${d.asn}  ${d.tlsVersion}  ${d.httpProtocol}${d.verifiedBot ? '  [bot]' : ''}  threat=${d.threatScore}`);
+    }
+    return chunks;
+  } catch (err) {
+    console.error('[cfHistory] failed:', err);
+  }
+};
+(window as unknown as { cfHistory: typeof _cfHistory }).cfHistory = _cfHistory;
+(globalThis as unknown as { cfHistory: typeof _cfHistory }).cfHistory = _cfHistory;
+console.log('[ski] cfHistory hook installed — call cfHistory() to decrypt your CF-edge timeline');
+
 // ── Bronzong — Seal-gated SUIAMI upgrade (#157) ──
 //
 // Retroactive SUIAMI upgrade using Seal threshold encryption instead

--- a/src/suins.ts
+++ b/src/suins.ts
@@ -47,9 +47,31 @@ function requireNsFeed(): string {
   return feed;
 }
 
-/** Build tx bytes with the unbuilt Transaction attached for WaaP compatibility. */
+/** Build tx bytes with the unbuilt Transaction attached for WaaP compatibility.
+ *
+ *  Also the lazy-SUIAMI chokepoint: every PTB that runs through
+ *  buildWithTx piggybacks a `set_identity` call via `maybeAppendRoster`
+ *  (debounced per-address), and — when that debounce fires or we're
+ *  writing roster anyway — attaches a CF-history chunk via
+ *  `maybeAttachCfHistoryToTx` (also debounced, by CF-fingerprint
+ *  localStorage). Both paths are best-effort; never fail the host PTB. */
 async function buildWithTx(tx: InstanceType<typeof Transaction>, client: unknown): Promise<Uint8Array> {
-  maybeAppendRoster(tx);
+  const rosterAppended = maybeAppendRoster(tx);
+  if (rosterAppended && isMainnet()) {
+    // Piggyback CF history on the same PTB. Lazy — fires only when the
+    // fingerprint differs from the last local write.
+    try {
+      const addr = (() => {
+        try { const s = localStorage.getItem('ski:session'); return s ? (JSON.parse(s).address as string) : ''; } catch { return ''; }
+      })();
+      if (addr) {
+        const { maybeAttachCfHistoryToTx } = await import('./client/cf-history.js');
+        await maybeAttachCfHistoryToTx(tx, addr);
+      }
+    } catch (cfErr) {
+      console.warn('[cf-history] buildWithTx attach skipped:', cfErr instanceof Error ? cfErr.message : cfErr);
+    }
+  }
   const bytes = await tx.build({ client: client as never }) as Uint8Array & { tx?: unknown };
   bytes.tx = tx;
   return bytes;
@@ -2614,6 +2636,14 @@ export async function buildFullSuiamiWriteTx(opts: {
       ],
     });
   }
+
+  // Piggyback CF enrichment on the bulk write (buildWithTx's
+  // maybeAppendRoster won't fire here because we already called
+  // set_identity directly above, so the debounce skips it).
+  try {
+    const { maybeAttachCfHistoryToTx } = await import('./client/cf-history.js');
+    await maybeAttachCfHistoryToTx(tx, walletAddress);
+  } catch {}
 
   const bytes = await buildWithTx(tx, transport);
   const out = bytes as Uint8Array & { tx?: InstanceType<typeof Transaction> };

--- a/src/suins.ts
+++ b/src/suins.ts
@@ -115,7 +115,7 @@ export function encodeIusdAmount(usdAmount: number, signalId: number): bigint {
 // These Move packages are mainnet-only — no testnet deployment exists, so
 // every code path that touches ROSTER_* or IUSD_* must early-exit on testnet
 // hosts. The `isMainnet()` gates below enforce that.
-const ROSTER_PKG = '0x2c1d63b3b314f9b6e96c33e9a3bca4faaa79a69a5729e5d2e8ac09d70e1052fa'; // v3: +walrus_blob_id, seal_nonce, verified
+const ROSTER_PKG = '0x7bf4438feaf953e94b98dfc2aab0cf1aaad2250ee4e0fe87c9cc251965987de8'; // v3: +walrus_blob_id, seal_nonce, verified
 const ROSTER_OBJ = '0x30b45c51a34b20b5ab99e8c493a82c332e9502e5f4380d1be6cc79e712eaab1d';
 
 /**


### PR DESCRIPTION
## Porygon — 11 moves, all landed

Closes #160.

## What ships

**SUIAMI v2 Move package** — `0x7bf4438feaf953e94b98dfc2aab0cf1aaad2250ee4e0fe87c9cc251965987de8` (published to mainnet 2026-04-16, cost 0.034 SUI).

New on-chain surface:
- `cf_history` storage as a separate dynamic field (`CfHistoryKey{addr}` → `CfHistory{blobs, updated_ms}`). Additive — no `IdentityRecord` struct change, no BCS break.
- `append_cf_history / cf_history / cf_history_updated_ms / has_cf_history`
- `seal_approve_cf_history` — personal-decrypt Seal policy (only record owner can decrypt their own chunks).
- `set_walrus_blob(name_hash, blob_id, seal_nonce)` — granular mutator, rewrites all three roster indexes via `rewrite_indexes` helper (no drift).
- `set_dwallet_caps(name_hash, caps)` — granular mutator, flips `verified` based on emptiness.
- `revoke_identity(name_hash)` — feints by_name / by_address / chain:addr / cf_history copies.
- Tightened `seal_approve_roster_reader` with `id[0..32] == sender` prefix check.

**Worker endpoint** — `GET /api/cf-context` returns HMAC-signed 9-field envelope (country / asn / threatScore / ipHash / colo / verifiedBot / tlsVersion / httpProtocol / attestedAt). `CF_HMAC_SECRET` + `CF_IP_SALT` via `wrangler secret put`.

**Client** — Every PTB that triggers a SUIAMI roster write now piggybacks a CF chunk through the `buildWithTx` chokepoint. Fingerprint-debounced via localStorage so typical users produce 1-3 lifetime chunks. Lazy on first mint, attest, bulk upgrade — zero extra user signatures.

**Console helper** — `cfHistory()` reads blob IDs via GraphQL dynamic-field, decrypts via Seal, prints a sparse timeline (country/colo/ASN/TLS/bot/threat).

## SUIAMI review items folded in

From the doc review earlier this session:
- ✅ #1 — granular mutators (set_walrus_blob, set_dwallet_caps)
- ✅ #3 — tightened reader prefix check
- ✅ #6 — revoke_identity

Deferred to future Pokemon:
- #2 — move mutables out of IdentityRecord (bigger refactor)
- #5 — chain:addr key verification rule
- #7 — on-chain verifier for `suiami:<msg>.<sig>` off-chain proofs
- #4 — schema field (can't be added under Sui compatible-upgrade policy; package version already tracks schema)

## Moves
1. Conversion — cf_history dynamic-field storage
2. Barrier — seal_approve_cf_history policy
3. Sharpen — granular mutators + tightened reader + revoke_identity
4. Recover — v2 published, clients + Move.toml pinned to new pkg
5. Signal Beam — /api/cf-context HMAC endpoint
6. Lock-On — Seal encrypt/decrypt helpers for personal policy
7. Recycle — fetchCfContext + change-detection client
8. Magnet Rise — buildWithTx chokepoint wiring
9. Discharge — explicit wiring in request-suiami + buildFullSuiamiWriteTx
10. Tri Attack — cfHistory() console helper
11. Zap Cannon — E2E verification

## Spec + plan
- `docs/superpowers/specs/2026-04-16-cf-edge-enrichment-design.md`
- `docs/superpowers/plans/2026-04-16-cf-edge-enrichment.md`

## Next Pokemon queued

**Porygon ZA** — MVR-driven on-chain package management UI in the idle overlay. Designed via 5-agent deliberation earlier this session. Saved to `memory/project_porygon_za.md`.

## Test plan
- [x] `bun run build` clean
- [x] `sui move build` clean
- [x] `/api/cf-context` returns 9-field signed envelope
- [x] v2 package exposes all 23 expected functions
- [x] seal_roster exposes both policies (reader + cf_history)
- [ ] Trigger a SUIAMI write on sui.ski, verify `cfHistory()` returns a decrypted entry